### PR TITLE
update SOA in zone template: honor rfc-recommended values for MNAME and EXPIRY

### DIFF
--- a/etc/alternc/templates/bind/templates/zone.template
+++ b/etc/alternc/templates/bind/templates/zone.template
@@ -11,7 +11,7 @@ $TTL @@ZONETTL@@
                 @@SERIAL@@      ; serial
                 21600           ; refresh (6h)
                 3600            ; retry (1h)
-                604800          ; expiry (7d)
+                1209600          ; expiry (14d)
                 @@ZONETTL@@ ) ; nxdomain TTL
 
                 IN      NS      %%ns1%%.

--- a/etc/alternc/templates/bind/templates/zone.template
+++ b/etc/alternc/templates/bind/templates/zone.template
@@ -7,7 +7,7 @@ $TTL @@ZONETTL@@
 ;; If you want to forbid automatic generation, change the LOCKED var
 ;; LOCKED:NO
 ;
-@       IN SOA %%fqdn%%. root.%%fqdn%%. (
+@       IN SOA %%ns1%%. root.%%fqdn%%. (
                 @@SERIAL@@      ; serial
                 21600           ; refresh (6h)
                 3600            ; retry (1h)


### PR DESCRIPTION
We were getting some warnings for the SOA values we had on our zones, with these modifications the warnings go away and the standards are better respected. hth
