### PR TITLE
fix opendkim signing for mails submitted over the network

### DIFF
--- a/jessie/alternc.install
+++ b/jessie/alternc.install
@@ -591,6 +591,7 @@ mkdir -p "/etc/opendkim/keys"
 touch /etc/opendkim/TrustedHosts /etc/opendkim/SigningTable /etc/opendkim/KeyTable
 grep -q "^127.0.0.1\$" /etc/opendkim/TrustedHosts || echo "127.0.0.1" >>/etc/opendkim/TrustedHosts
 grep -q "^localhost\$" /etc/opendkim/TrustedHosts || echo "localhost" >>/etc/opendkim/TrustedHosts
+grep -q "^$PUBLIC_IP\$" /etc/opendkim/TrustedHosts || echo "$PUBLIC_IP" >>/etc/opendkim/TrustedHosts
 
 # Add opendkim to service to restart
 SERVICES="$SERVICES opendkim"


### PR DESCRIPTION
mails submitted over smtp, and not sent via webmail was not being signed by opendkim because the external ip of the hosting server was missing from the trustedhosts file
