### PR TITLE
Prevent alternc from trying to delete $ALTERNC_LOGS

### DIFF
--- a/src/delete_logs.sh
+++ b/src/delete_logs.sh
@@ -17,4 +17,4 @@ done
 stop_if_jobs_locked
 
 # ALTERNC_LOGS is from local.sh
-find "$ALTERNC_LOGS" -mtime +$DAYS -delete
+find "$ALTERNC_LOGS" -mtime +$DAYS -type f -delete


### PR DESCRIPTION
We only want the system to delete files, not directories. It ends up complaining to site administrators that it can't delete $ALTERNC_LOGS