### PR TITLE
log entries for error and log both log IP address

### DIFF
--- a/bureau/class/m_err.php
+++ b/bureau/class/m_err.php
@@ -119,7 +119,7 @@ class m_err {
      */
     function logerr() {
         global $mem;
-        @file_put_contents($this->logfile, date("d/m/Y H:i:s") . " - ERROR - " . $mem->user["login"] . " - " . $this->errstr(), FILE_APPEND);
+        @file_put_contents($this->logfile, date("d/m/Y H:i:s") . " - " . get_remote_ip() . " - ERROR - " . $mem->user["login"] . " - " . $this->errstr(), FILE_APPEND);
     }
 
     /**


### PR DESCRIPTION
Logfile did not contain the IP address of the client in case of error. This can be usefull to filter out attacks, such as login bruteforce.