### PR TITLE
Error on isset for X_FORWARDED_PROTO

### DIFF
--- a/bureau/class/config.php
+++ b/bureau/class/config.php
@@ -167,7 +167,7 @@ $err = new m_err();
 $authip = new m_authip();
 $hooks = new m_hooks();
 
-if (!isset($_SERVER["HTTP_X_FORWARDED_PROTO"]) && $_SERVER["HTTP_X_FORWARDED_PROTO"]=="https") {
+if (isset($_SERVER["HTTP_X_FORWARDED_PROTO"]) && $_SERVER["HTTP_X_FORWARDED_PROTO"]=="https") {
     $_SERVER["HTTPS"]="on";
 }
 


### PR DESCRIPTION
Should be `isset($_SERVER["HTTP_X_FORWARDED_PROTO"])` and not `!isset($_SERVER["HTTP_X_FORWARDED_PROTO"])`

Avoid a notice : 

`PHP Notice:  Undefined index: HTTP_X_FORWARDED_PROTO in /usr/share/alternc/panel/class/config.php on line 170`