### PR TITLE
Protected dir creation error messages are not helpful.

### DIFF
--- a/bureau/class/m_hta.php
+++ b/bureau/class/m_hta.php
@@ -73,13 +73,9 @@ class m_hta {
             return false;
         }
         if (!file_exists("$absolute/.htaccess")) {
-            if (!@touch("$absolute/.htaccess")) {
-                $msg->raise("ERROR", "hta", _("File already exist"));
-                return false;
-            }
-            $file = @fopen("$absolute/.htaccess", "r+");
+            $file = @fopen("$absolute/.htaccess", "w+");
             if (!$file) {
-                $msg->raise("ERROR", "hta", _("File already exist"));
+                $msg->raise("ERROR", "hta", _("Error creating .htaccess file: ") . error_get_last()['message']);
                 return false;
             }
             fseek($file, 0);
@@ -88,8 +84,8 @@ class m_hta {
             fclose($file);
         }
         if (!file_exists("$absolute/.htpasswd")) {
-            if (!touch("$absolute/.htpasswd")) {
-                $msg->raise("ERROR", "hta", _("File already exist"));
+            if (!@touch("$absolute/.htpasswd")) {
+                $msg->raise("ERROR", "hta", _("Error creating .htpasswd file: ") . error_get_last()['message']);
                 return false;
             }
             return true;


### PR DESCRIPTION
Current error messages that are shown and logged when a problem occurs
when creating htaccess and htpasswd files for a protected dir are really
not helpful.

The messages don't even mention which file caused the error.

Sometimes when the files can't be created, it's not because they're
already present, for example when there's a permission error.
Also we've already verified that they are absent with file_exists so
the current error message is not accurate at all!

To empower users, we need to give them more details about the error. For
that we want to show the error that the file creation logged itself.

Finally, we've already verified that the htacces file already exists, so
there's no point in using touch beforehand. We should just let fopen try
to create the file and report whatever went wrong if anything happens.