### PR TITLE
Fix #225: call fetchAll on PDO statement

### DIFF
--- a/roundcube/class/m_roundcube.php
+++ b/roundcube/class/m_roundcube.php
@@ -101,7 +101,7 @@ class m_roundcube {
     $req=$stmt->execute(array($fullmail));
 
     if ($req) {
-    foreach ( $req->fetchAll() as $t ) {
+    foreach ( $stmt->fetchAll() as $t ) {
       if (empty($t['user_id'])) continue ;
       $rcuser_id=$t['user_id'];
 


### PR DESCRIPTION
The result of PDO::execute() is always a boolean. The statement itself needs to be used with fetchAll()