### PR TITLE
Fix #227: Use stronger password hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 # Purpose of file: Global Makefile 
 # ----------------------------------------------------------------------
 MAJOR=$(shell sed -ne 's/^[^(]*(\([^)]*\)).*/\1/;1p' debian/changelog)
-VERSION=$MAJOR
+VERSION=$(MAJOR)
 export VERSION
 
 build:

--- a/bureau/class/functions.php
+++ b/bureau/class/functions.php
@@ -541,20 +541,6 @@ function _md5cr($pass, $salt = "") {
     return crypt($pass, $salt);
 }
 
-/**
- * Transtional function to check if a string matches a saved password hash.
- * @param string $pass string
- * @param string $hash string
- * @return bool
- */
-function _password_verify($pass, $hash) {
-    if (strncmp($hash, '$1$', 3) == 0) {
-        // @TODO Raise a warning for the user to update their password.
-        return _md5cr($pass, $hash) == $hash;
-    }
-    return password_verify($pass, $hash);
-}
-
 /** split mysql database name between username and custom database name
  * @param string $dbname database name
  * @return array returns username as first element, custom name as second

--- a/bureau/class/functions.php
+++ b/bureau/class/functions.php
@@ -541,6 +541,19 @@ function _md5cr($pass, $salt = "") {
     return crypt($pass, $salt);
 }
 
+/**
+ * Transtional function to check if a string matches a saved password hash.
+ * @param string $pass string
+ * @param string $hash string
+ * @return bool
+ */
+function _password_verify($pass, $hash) {
+    if (strncmp($hash, '$1$', 3) == 0) {
+        // @TODO Raise a warning for the user to update their password.
+        return _md5cr($pass, $hash) == $hash;
+    }
+    return password_verify($pass, $hash);
+}
 
 /** split mysql database name between username and custom database name
  * @param string $dbname database name

--- a/bureau/class/m_admin.php
+++ b/bureau/class/m_admin.php
@@ -634,7 +634,7 @@ class m_admin {
             $msg->raise("ERROR", "admin", _("Login can only contains characters a-z, 0-9 and -"));
             return false;
         }
-        $pass = _md5cr($pass);
+        $pass = password_hash($pass);
         $db = new DB_System();
         // Already exist?
         $db->query("SELECT count(*) AS cnt FROM membres WHERE login= ?;", array($login));
@@ -772,7 +772,7 @@ class m_admin {
         $db = new DB_System();
 
         if ($pass) {
-            $pass = _md5cr($pass);
+            $pass = password_hash($pass);
             $second_query = "UPDATE membres SET mail= ?, canpass= ?, enabled= ?, `type`= ?, notes= ? , pass = ? WHERE uid= ?;";
             $second_query_args = array($mail, $canpass, $enabled, $type, $notes, $pass, $uid);
         } else {

--- a/bureau/class/m_admin.php
+++ b/bureau/class/m_admin.php
@@ -634,7 +634,7 @@ class m_admin {
             $msg->raise("ERROR", "admin", _("Login can only contains characters a-z, 0-9 and -"));
             return false;
         }
-        $pass = password_hash($pass);
+        $pass = password_hash($pass, PASSWORD_BCRYPT);
         $db = new DB_System();
         // Already exist?
         $db->query("SELECT count(*) AS cnt FROM membres WHERE login= ?;", array($login));
@@ -772,7 +772,7 @@ class m_admin {
         $db = new DB_System();
 
         if ($pass) {
-            $pass = password_hash($pass);
+            $pass = password_hash($pass, PASSWORD_BCRYPT);
             $second_query = "UPDATE membres SET mail= ?, canpass= ?, enabled= ?, `type`= ?, notes= ? , pass = ? WHERE uid= ?;";
             $second_query_args = array($mail, $canpass, $enabled, $type, $notes, $pass, $uid);
         } else {

--- a/bureau/class/m_ftp.php
+++ b/bureau/class/m_ftp.php
@@ -321,7 +321,7 @@ class m_ftp {
                     return false; // The error has been raised by checkPolicy()
                 }
             }
-            $encrypted_password = _md5cr($pass, strrev(microtime(true)));
+            $encrypted_password = _sha512cr($pass);
             $db->query("UPDATE ftpusers SET name= ? , password='', encrypted_password= ?, homedir= ?, uid= ? WHERE id= ?;", array($full_login, $encrypted_password, $absolute, $cuid, $id));
         } else {
             $db->query("UPDATE ftpusers SET name= ? , homedir= ? , uid= ? WHERE id= ? ;", array($full_login, $absolute, $cuid, $id));
@@ -406,7 +406,7 @@ class m_ftp {
         }
 
         if ($quota->cancreate("ftp")) {
-            $encrypted_password = _md5cr($pass, strrev(microtime(true)));
+            $encrypted_password = _sha512cr($pass);
             $db->query("INSERT INTO ftpusers (name,password, encrypted_password,homedir,uid) VALUES ( ?, '', ?, ?, ?)", array($full_login, $encrypted_password, $absolute, $cuid));
             return true;
         } else {

--- a/bureau/class/m_mail.php
+++ b/bureau/class/m_mail.php
@@ -620,8 +620,10 @@ ORDER BY
             return false;
         }
         if ($canbeempty && empty($pass)) {
-            return $db->query("UPDATE address SET password= ? where id = ? ;", array(null, $mail_id ));
-        } else if (!$db->query("UPDATE address SET password= ? where id = ? ;", array(_md5cr($pass), $mail_id ))) {
+            return $db->query("UPDATE address SET password= ? where id = ? ;",
+                              array(null, $mail_id ));
+        } else if (!$db->query("UPDATE address SET password= ? where id = ? ;",
+                               array(_dovecot_hash($pass), $mail_id ))) {
             return false;
         }
         return true;

--- a/bureau/class/m_mem.php
+++ b/bureau/class/m_mem.php
@@ -104,6 +104,12 @@ class m_mem {
         }
         $this->user = $db->Record;
         $cuid = $db->f("uid");
+        // Transitional code to update md5 hashed passwords to those created
+        // with password_hash().
+        if (strncmp($db->f('pass'), '$1$', 3) == 0) {
+            $db->query("update membres set pass = ? where uid = ?",
+                       array(password_hash($password), $cuid));
+        }
 
         if (panel_islocked() && $cuid != 2000) {
             $msg->raise("ALERT", "mem", _("This website is currently under maintenance, login is currently disabled."));

--- a/bureau/class/m_mem.php
+++ b/bureau/class/m_mem.php
@@ -93,7 +93,7 @@ class m_mem {
             return false;
         }
         $db->next_record();
-        if (!_password_verify($password, $db->f('pass'))) {
+        if (!password_verify($password, $db->f('pass'))) {
             $db->query("UPDATE membres SET lastfail=lastfail+1 WHERE uid= ? ;", array($db->f("uid")));
             $msg->raise("ERROR", "mem", _("User or password incorrect"));
             return false;
@@ -396,7 +396,7 @@ class m_mem {
             $msg->raise("ERROR", "mem", _("You are not allowed to change your password."));
             return false;
         }
-        if (!_password_verify($oldpass, $this->user['pass'])) {
+        if (!password_verify($oldpass, $this->user['pass'])) {
             $msg->raise("ERROR", "mem", _("The old password is incorrect"));
             return false;
         }

--- a/bureau/class/m_mem.php
+++ b/bureau/class/m_mem.php
@@ -93,7 +93,7 @@ class m_mem {
             return false;
         }
         $db->next_record();
-        if (_md5cr($password, $db->f("pass")) != $db->f("pass")) {
+        if (!_password_verify($password, $db->f('pass'))) {
             $db->query("UPDATE membres SET lastfail=lastfail+1 WHERE uid= ? ;", array($db->f("uid")));
             $msg->raise("ERROR", "mem", _("User or password incorrect"));
             return false;
@@ -396,7 +396,7 @@ class m_mem {
             $msg->raise("ERROR", "mem", _("You are not allowed to change your password."));
             return false;
         }
-        if ($this->user["pass"] != _md5cr($oldpass, $this->user["pass"])) {
+        if (!_password_verify($oldpass, $this->user['pass'])) {
             $msg->raise("ERROR", "mem", _("The old password is incorrect"));
             return false;
         }
@@ -410,7 +410,7 @@ class m_mem {
         if (!$admin->checkPolicy("mem", $login, $newpass)) {
             return false; // The error has been raised by checkPolicy()
         }
-        $newpass = _md5cr($newpass);
+        $newpass = password_hash($newpass);
         $db->query("UPDATE membres SET pass= ? WHERE uid= ?;", array($newpass, $cuid));
         $msg->init_msgs();
         return true;

--- a/bureau/class/m_mem.php
+++ b/bureau/class/m_mem.php
@@ -108,7 +108,7 @@ class m_mem {
         // with password_hash().
         if (strncmp($db->f('pass'), '$1$', 3) == 0) {
             $db->query("update membres set pass = ? where uid = ?",
-                       array(password_hash($password), $cuid));
+                       array(password_hash($password, PASSWORD_BCRYPT), $cuid));
         }
 
         if (panel_islocked() && $cuid != 2000) {
@@ -416,7 +416,7 @@ class m_mem {
         if (!$admin->checkPolicy("mem", $login, $newpass)) {
             return false; // The error has been raised by checkPolicy()
         }
-        $newpass = password_hash($newpass);
+        $newpass = password_hash($newpass, PASSWORD_BCRYPT);
         $db->query("UPDATE membres SET pass= ? WHERE uid= ?;", array($newpass, $cuid));
         $msg->init_msgs();
         return true;

--- a/install/mysql.sql
+++ b/install/mysql.sql
@@ -159,7 +159,7 @@ CREATE TABLE IF NOT EXISTS local (
 CREATE TABLE IF NOT EXISTS membres (
   uid int(10) unsigned NOT NULL auto_increment,		-- Numéro du membre (GID)
   login varchar(128) NOT NULL default '',		-- Nom d`utilisateur
-  pass varchar(64) NOT NULL default '',			-- Mot de passe
+  pass varchar(255) NOT NULL default '',			-- Mot de passe
   enabled tinyint(4) NOT NULL default '1',		-- Le compte est-il actif ?
   su tinyint(4) NOT NULL default '0',			-- Le compte est-il super-admin ?
   mail varchar(128) NOT NULL default '',		-- Adresse email du possesseur

--- a/install/mysql.sql
+++ b/install/mysql.sql
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS ftpusers (
   id int(10) unsigned NOT NULL auto_increment,
   name varchar(64) NOT NULL default '',
   password varchar(32) NOT NULL default '',
-  encrypted_password VARCHAR(32) default NULL,
+  encrypted_password VARCHAR(255) default NULL,
   homedir varchar(128) NOT NULL default '',
   uid int(10) unsigned NOT NULL default '0',
   enabled boolean NOT NULL DEFAULT TRUE,

--- a/install/upgrades/3.4.11.sql
+++ b/install/upgrades/3.4.11.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `membres` MODIFY `pass` varchar(255);

--- a/install/upgrades/3.4.11.sql
+++ b/install/upgrades/3.4.11.sql
@@ -1,1 +1,2 @@
 ALTER TABLE `membres` MODIFY `pass` varchar(255);
+ALTER TABLE `ftpusers` MODIFY `encrypted_password` varchar(255);


### PR DESCRIPTION
Requires PHP >= 5.5. It may be necessary to add a dependency on php5 ssl or mcrypt for jessie for the _sha512cr salt. No automatic transition for ftpuser / dovecot passwords, but new accounts or updating the password will do the trick.