### PR TITLE
Fix #221: Get sub_domain_id and status from get instead of post in dom_substatus

### DIFF
--- a/bureau/admin/dom_substatus.php
+++ b/bureau/admin/dom_substatus.php
@@ -26,8 +26,8 @@
 require_once("../class/config.php");
 
 $fields = array (
-  "sub_id"    => array ("post", "integer", ""),
-  "status"    => array ("post", "string", ""),
+  "sub_id"    => array ("get", "integer", ""),
+  "status"    => array ("get", "string", ""),
 );
 getFields($fields);
 


### PR DESCRIPTION
The submission is done through links with get parameters (see dom_edit.php)