### PR TITLE
Fix #233: Generate opendkim configuration in stretch when alternc.install is run

### DIFF
--- a/etc/alternc/templates/opendkim.conf
+++ b/etc/alternc/templates/opendkim.conf
@@ -14,3 +14,7 @@ KeyTable           /etc/opendkim/KeyTable
 SigningTable       /etc/opendkim/SigningTable
 ExternalIgnoreList /etc/opendkim/TrustedHosts
 InternalHosts      /etc/opendkim/TrustedHosts
+
+# The value from /etc/default/opendkim doesn't seem to be taken into account
+# @see https://bugs.debian.org/cgi-bin/bugreport.cgi?archive=no&bug=861169
+Socket             local:/var/run/opendkim/opendkim.sock

--- a/install/alternc.install
+++ b/install/alternc.install
@@ -595,6 +595,15 @@ touch /etc/opendkim/TrustedHosts /etc/opendkim/SigningTable /etc/opendkim/KeyTab
 grep -q "^127.0.0.1\$" /etc/opendkim/TrustedHosts || echo "127.0.0.1" >>/etc/opendkim/TrustedHosts
 grep -q "^localhost\$" /etc/opendkim/TrustedHosts || echo "localhost" >>/etc/opendkim/TrustedHosts
 grep -q "^$PUBLIC_IP\$" /etc/opendkim/TrustedHosts || echo "$PUBLIC_IP" >>/etc/opendkim/TrustedHosts
+if [ "$(lsb_release -s -c)" == 'stretch' ] ; then
+    /lib/opendkim/opendkim.service.generate
+    # Without adding '-u opendkim' after the service file is generated, opendkim
+    # will run as root, which we do not want.
+    if [ "$(grep -c 'u opendkim' /etc/systemd/system/opendkim.service.d/override.conf)" == 0 ] ; then
+        sed 's/inet:8891@127.0.0.1/& -u opendkim/' /etc/systemd/system/opendkim.service.d/override.conf
+    fi
+    systemctl daemon-reload
+fi
 
 # Add opendkim to service to restart
 SERVICES="$SERVICES opendkim"

--- a/install/alternc.install
+++ b/install/alternc.install
@@ -600,7 +600,7 @@ if [ "$(lsb_release -s -c)" == 'stretch' ] ; then
     # Without adding '-u opendkim' after the service file is generated, opendkim
     # will run as root, which we do not want.
     if [ "$(grep -c 'u opendkim' /etc/systemd/system/opendkim.service.d/override.conf)" == 0 ] ; then
-        sed 's/inet:8891@127.0.0.1/& -u opendkim/' /etc/systemd/system/opendkim.service.d/override.conf
+        sed -i -e 's/inet:8891@127.0.0.1/& -u opendkim/' /etc/systemd/system/opendkim.service.d/override.conf
     fi
     systemctl daemon-reload
 fi


### PR DESCRIPTION
The default configuration in stretch doesn't work very well and
needs a couple of tweaks. This will generate the service files and
make sure opendkim is run as the opendkim user instead of root.

The alternc opendkim.conf template is updated so that the connection
can be made locally through a socket.