### PR TITLE
Fix #257: Add trailing slash to VHOST_DIR when building vhosts_all.conf

### DIFF
--- a/src/update_domains.sh
+++ b/src/update_domains.sh
@@ -129,7 +129,7 @@ if [ ! -z "$(cat "$RELOAD_WEB")" ] ; then
 
   (
     echo "###BEGIN OF ALTERNC AUTO-GENERATED FILE - DO NOT EDIT MANUALLY###"
-    find "$VHOST_DIR" -mindepth 2 -type f -iname "*.conf" -print0 | xargs -0 cat 
+    find "$VHOST_DIR"/ -mindepth 2 -type f -iname "*.conf" -print0 | xargs -0 cat
     echo "###END OF ALTERNC AUTO-GENERATED FILE - DO NOT EDIT MANUALLY###" 
   ) > "$tempo"
 


### PR DESCRIPTION
If VHOST_DIR is a symbolic link to another folder, no files will be found,
resulting in an empty vhosts_all.conf. A trailing slash ensures find will
properly resolve the symbolic link before searching.