### PR TITLE
Do not use fixed sed script path

### DIFF
--- a/install/alternc.install
+++ b/install/alternc.install
@@ -230,7 +230,7 @@ EOF
 
 # hook 
 test -d /usr/lib/alternc/install.d || mkdir -p /usr/lib/alternc/install.d
-run-parts --arg=templates /usr/lib/alternc/install.d 
+run-parts --arg=templates --arg="$SED_SCRIPT" /usr/lib/alternc/install.d
 
 
 ######################################################################

--- a/install/alternc.install
+++ b/install/alternc.install
@@ -201,9 +201,7 @@ PUBLIC_IP_BEGIN=$(echo $PUBLIC_IP|cut -c 1)
 # Secret for PhpMyAdmin sessions
 PHPMYADMIN_BLOWFISH="$(generate_string 24)"
 
-# XXX: I assume this is secure if /tmp is sticky (+t)
-# we should have a better way to deal with templating, of course.
-SED_SCRIPT="/tmp/alternc.install.sedscript"
+SED_SCRIPT=$(mktemp)
 cat > $SED_SCRIPT <<EOF
 s\\%%hosting%%\\$HOSTING\\;
 s\\%%fqdn%%\\$FQDN\\;


### PR DESCRIPTION
 Use mktemp to get the filename for storing the templating script
    
 Using a fixed string could allow for abuse by anyone who has access to /tmp. One could place a symbolic link to any file to cause it to be overwritten when alternc.install is run.

The location of the sed script is passed as a second argument to scripts in /usr/lib/share/alternc/install.d when the template hook is called.