### PR TITLE
Don't grab disabled domains when generating configuration fixes #272

### DIFF
--- a/bureau/class/m_dom.php
+++ b/bureau/class/m_dom.php
@@ -2045,7 +2045,8 @@ class m_dom {
                   domaines_type dt 
                 where 
                   v.name='mailname_bounce' 
-                  and lower(dt.name) = lower(sd.type)"; 
+                  and lower(dt.name) = lower(sd.type)
+                  and ( sd.enable='ENABLED' or sd.enable='ENABLE')"; 
         $query_args =   array();
 
         if (!is_null($id) && intval($id) == $id) {


### PR DESCRIPTION
Currently when we disable a sub-domain, the DNS entry gets removed, if
dns is locally managed, but the apache vhost is always added to
vhosts_all.conf.

This means that for domains that don't have local DNS management, the
disable link has no effect!

attention: je n'ai pas testé mon commit! je pense faire ca dans les prochains jours