### PR TITLE
add php config for sys_temp_dir in vhost templates (for PHP 5.4+)

### DIFF
--- a/etc/alternc/templates/apache2/vhost-both.conf
+++ b/etc/alternc/templates/apache2/vhost-both.conf
@@ -7,6 +7,7 @@
   <Directory "%%document_root%%">
     php_admin_value open_basedir "%%account_root%%:/usr/share/php/"
     php_admin_value upload_tmp_dir %%account_root%%/tmp
+    php_admin_value sys_temp_dir %%account_root%%/tmp
     php_admin_value sendmail_path '/usr/lib/alternc/sendmail "%%mail_account%%" '
     php_admin_flag mail.add_x_header on
     Options +MultiViews -FollowSymLinks +SymLinksIfOwnerMatch
@@ -24,6 +25,7 @@
   <Directory "%%document_root%%">
     php_admin_value open_basedir "%%account_root%%:/usr/share/php/"
     php_admin_value upload_tmp_dir %%account_root%%/tmp
+    php_admin_value sys_temp_dir %%account_root%%/tmp
     php_admin_value sendmail_path '/usr/lib/alternc/sendmail "%%mail_account%%" '
     php_admin_flag mail.add_x_header on
     Options +MultiViews -FollowSymLinks +SymLinksIfOwnerMatch

--- a/etc/alternc/templates/apache2/vhost-http.conf
+++ b/etc/alternc/templates/apache2/vhost-http.conf
@@ -21,6 +21,7 @@
   <Directory "%%document_root%%">
     php_admin_value open_basedir "%%account_root%%:/usr/share/php/"
     php_admin_value upload_tmp_dir %%account_root%%/tmp
+    php_admin_value sys_temp_dir %%account_root%%/tmp
     php_admin_value sendmail_path '/usr/lib/alternc/sendmail "%%mail_account%%" '
     php_admin_flag mail.add_x_header on
     Options -MultiViews -FollowSymLinks +SymLinksIfOwnerMatch

--- a/etc/alternc/templates/apache2/vhost-https.conf
+++ b/etc/alternc/templates/apache2/vhost-https.conf
@@ -20,6 +20,7 @@
   <Directory "%%document_root%%">
     php_admin_value open_basedir "%%account_root%%:/usr/share/php/"
     php_admin_value upload_tmp_dir %%account_root%%/tmp
+    php_admin_value sys_temp_dir %%account_root%%/tmp
     php_admin_value sendmail_path '/usr/lib/alternc/sendmail "%%mail_account%%" '
     php_admin_flag mail.add_x_header on
     Options +MultiViews -FollowSymLinks +SymLinksIfOwnerMatch


### PR DESCRIPTION
Add one php_admin_value in vhosts templates to configure the value returned by get_sys_temp_dir().
This INI setting exists from PHP 5.4+ (so this patch should be reverted for Debian lower than Jessie)
