### PR TITLE
Issue #277: Symlink vhost.conf to vhost-http.conf

### DIFF
--- a/etc/alternc/templates/apache2/vhost.conf
+++ b/etc/alternc/templates/apache2/vhost.conf
@@ -1,0 +1,1 @@
+vhost-http.conf


### PR DESCRIPTION
Ensures existing sub_domaines entries with 'vhost' don't break