### PR TITLE
Change wording of HTTPS state for subdomains

### DIFF
--- a/bureau/admin/dom_edit.php
+++ b/bureau/admin/dom_edit.php
@@ -197,7 +197,12 @@ if (!$r["sub"][$i]["only_dns"]) {
         __("HTTP and HTTPS");
         break;
     default:
-        __("Unknown");
+        if ($r['sub'][$i]['has_https_option']) {
+            __("Unknown");
+        }
+        else {
+            __('Not applicable');
+        }
         break;
     }
 }


### PR DESCRIPTION
Show 'Not applicable' when the type of the subdomain does not have an https option.