### PR TITLE
Fix roundcube webmail access

### DIFF
--- a/debian/alternc-roundcube.postinst
+++ b/debian/alternc-roundcube.postinst
@@ -11,11 +11,6 @@ LOGROTATE="/etc/logrotate.d/roundcube-core"
 case "$1" in
     configure)
 	
-        # add alternc-roundcube user for php-itk special rights
-	if ! getent passwd alternc-roundcube; then
-	    useradd -g nogroup -u 1996 alternc-roundcube -d /usr/share/roundcube
-	fi
-
 	# removed from 3.1 & 3.2 :
 	dpkg-statoverride --list /var/lib/roundcube/temp >/dev/null &&  
 	dpkg-statoverride --remove /var/lib/roundcube/temp

--- a/roundcube/roundcube-install
+++ b/roundcube/roundcube-install
@@ -81,9 +81,8 @@ EOF
 fi
 
 if [ "$1" = "end" ]; then
-  # This is necessary because upgrading roundcube from 7.1 to 7.2 changes this setting
-  chown alternc-roundcube:root /etc/roundcube/config.inc.php
-  # In case owner is reset to www-data
-  chown alternc-roundcube:nogroup /var/lib/roundcube/temp
+  # Roundcube vhosts run as www-data instead of alternc-roundcube now.
+  # Ensure the configuration is owned by the appropriate user.
+  chown www-data:root /etc/roundcube/config.inc.php
+  chown www-data:nogroup /var/lib/roundcube/temp
 fi
-

--- a/roundcube/templates/apache2/roundcube.conf
+++ b/roundcube/templates/apache2/roundcube.conf
@@ -37,20 +37,19 @@
   <Directory /var/lib/roundcube/config>
     Options -FollowSymLinks
     AllowOverride None
+    Require all denied
   </Directory>
 
   <Directory /var/lib/roundcube/temp>
     Options -FollowSymLinks
     AllowOverride None
-    Order allow,deny
-    Deny from all
+    Require all denied
   </Directory>
 
   <Directory /var/lib/roundcube/logs>
     Options -FollowSymLinks
     AllowOverride None
-    Order allow,deny
-    Deny from all
+    Require all denied
   </Directory>
 
   Alias /javascript /usr/share/javascript/

--- a/roundcube/templates/apache2/roundcube.conf
+++ b/roundcube/templates/apache2/roundcube.conf
@@ -20,9 +20,9 @@
 
   # Access to tinymce files
   <Directory "/usr/share/tinymce/www/">
-        Options +Indexes +MultiViews +FollowSymLinks
-        AllowOverride None
-  	Require all granted
+    Options +Indexes +MultiViews +FollowSymLinks
+    AllowOverride None
+    Require all granted
   </Directory>
 
   <Directory /var/lib/roundcube/>
@@ -56,8 +56,8 @@
   Alias /javascript /usr/share/javascript/
 
   <Directory "/usr/share/javascript/">
-        Options +FollowSymLinks +MultiViews
-  	Require all granted
+    Options +FollowSymLinks +MultiViews
+    Require all granted
   </Directory>
 
   SSLEngine On


### PR DESCRIPTION
Roundcube vhosts run as www-data:www-data, but alternc.install was changing the ownership of the configuration to alternc-roundcube causing the application to be unable to read the configuration and load.

Also removed creation of the alternc-roundcube user during install of alternc-roundcube as it's not used.

@see #285 