### PR TITLE
Fix #287: php zone regeneration behaviour

### DIFF
--- a/bureau/class/class_system_bind.php
+++ b/bureau/class/class_system_bind.php
@@ -502,8 +502,8 @@ class system_bind {
 
             if ( ( $all || strtoupper($ds['dns_action']) == 'UPDATE' ) && $ds['gesdns'] ) {
                 $this->save_zone($domain);
-                $this->reload_zone($domain);
                 $hooks->invoke_scripts("/usr/lib/alternc/reload.d", array('dns_reload_zone', $domain)  );
+                $this->reload_zone($domain);
             }
         } // end foreach domain
 

--- a/bureau/class/m_hooks.php
+++ b/bureau/class/m_hooks.php
@@ -82,6 +82,8 @@ class m_hooks {
             }
         } else if (is_dir($scripts)) {
             foreach (scandir($scripts) as $ccc) {
+                # scandir returns the file names only
+                $ccc = $scripts . '/' . $ccc;
                 if (is_file($ccc) && is_executable($ccc)) {
                     $to_launch[] = $ccc;
                 }


### PR DESCRIPTION
Fixes invoke_scripts where the script is a directory; and matches the dns_reload_zone hook order between the PHP version and bash version.