### PR TITLE
Issue #102: Add password reset via one-time login link

### DIFF
--- a/bureau/admin/index.php
+++ b/bureau/admin/index.php
@@ -87,7 +87,8 @@ if ( empty($logo) ||  ! $logo ) {
 	</div>
       </div>
       <div class="block_login_page">
-
+        <a href="request_reset.php"><?php echo _('Request new password'); ?></a>
+        <br />
         <?php __("You must accept the session cookie to log-in"); ?>
         <br />
         <?php echo _("If you want to use a different language, choose it in the list below"); ?>

--- a/bureau/admin/mem_param.php
+++ b/bureau/admin/mem_param.php
@@ -81,7 +81,9 @@ echo "<p>";
 <input type="password" style="display: none" id="fakePassword" name="fakePassword" value="" />
 
 <table border="1" cellspacing="0" cellpadding="4" class="tedit" >
-<tr><th><?php __("Old password"); ?></th><td><input type="password" class="int" name="oldpass" value="<?php isset($oldpass) ? : $oldpass=""; ehe($oldpass); ?>" size="20" maxlength="128" /></td></tr>
+<?php if ($mem->requires_old_password_for_change()): ?>
+    <tr><th><?php __("Old password"); ?></th><td><input type="password" class="int" name="oldpass" value="<?php isset($oldpass) ? : $oldpass=""; ehe($oldpass); ?>" size="20" maxlength="128" /></td></tr>
+<?php endif; ?>
 <tr><th><?php __("New password"); ?> (1)</th><td><input type="password" class="int" autocomplete="off" id="newpass" name="newpass" value="<?php isset($newpass) ? : $newpass=""; ehe($newpass);  ?>" size="20" maxlength="60" /><?php display_div_generate_password(DEFAULT_PASS_SIZE,"#newpass","#newpass2",$passwd_classcount); ?></td></tr>
 <tr><th><?php __("New password"); ?> (2)</th><td><input type="password" class="int" autocomplete="off" id="newpass2" name="newpass2" value="<?php isset($newpass2) ? : $newpass2=""; ehe($newpass2);?>" size="20" maxlength="61" /></td></tr>
 <tr class="trbtn"><td colspan="3"><input type="submit" class="inb ok" name="submit" value="<?php __("Change my password"); ?>" /></td></tr>
@@ -134,8 +136,13 @@ if ($mem->user["su"]) {
 </div> <!-- tabsmem -->
 
 <script type="text/javascript">
-document.forms['main'].oldpass.focus();
-$(function() {$( "#tabsmem" ).tabs();});
+    if (document.forms['main'].getElementsByClassName("oldpass").length > 0) {
+        document.forms['main'].oldpass.focus();
+    }
+    else {
+        document.getElementById('newpass').focus();
+    }
+    $(function() {$( "#tabsmem" ).tabs();});
 </script>
 
 <?php include_once("foot.php"); ?>

--- a/bureau/admin/request_reset.php
+++ b/bureau/admin/request_reset.php
@@ -1,0 +1,72 @@
+<?php
+
+require_once("../class/config_nochk.php");
+
+$request = FALSE;
+$valid_request = TRUE;
+if (isset($_REQUEST['name_or_email'])) {
+    $request = TRUE;
+    // Inserted into the global namespace by config.php
+    $valid_request = !$fatalcsrf;
+    if ($fatalcsrf) {
+        $msg->raise('ERROR', _('Failed to validate CSRF token'));
+    }
+}
+
+
+// Show the form if nothing was submitted, or if what was submitted is not
+// a valid request (eg. doesn't pass CSRF).
+$show_form =  !$request || ($request && !$valid_request);
+
+if ($request && $valid_request) {
+    $mem->send_reset_url($_REQUEST['name_or_email']);
+}
+
+if (!isset($charset) || ! $charset) {
+    $charset="UTF-8";
+}
+
+@header("Content-Type: text/html; charset=$charset");
+require_once("html-head.php");
+?>
+
+<body class="login_page">
+    <div id="global">
+        <div id="content">
+            <?php
+            // Getting logo. C.f. admin/index.php
+            $logo = variable_get('logo_login', '' ,'You can specify a logo for the login page, example /images/my_logo.png .', array('desc'=>'URL','type'=>'string'));
+            if ( empty($logo) ||  ! $logo ) {
+                $logo = 'images/logo.png';
+            }
+            ?>
+            <p id='logo'>  <img src="<?php echo $logo; ?>" border="0" height="100px" alt="<?php __("Web Hosting Control Panel"); ?>" title="<?php __("Web Hosting Control Panel"); ?>" />
+            </p>
+            <p>&nbsp;</p>
+            <?php echo $msg->msg_html_all(); ?>
+            <br/>
+            <div class="block_list">
+              <?php if ($show_form): ?>
+                <div class="block_login_page">
+                        <div class="menu-box">
+                            <div class="menu-title"><?php echo _('Password reset'); ?></div>
+                            <form action="request_reset.php" method="post" name="passwordreset">
+                                <?php csrf_get(); ?>
+                                <div>
+                                    <label for="name_or_email"><?php echo _('Username or e-mail'); ?></label>
+                                    <input type="text" class="int" name="name_or_email">
+                                </div>
+                                <div class="submit"><input type="submit" class="inb" name="submit"></div>
+                            </form>
+                        </div>
+                </div>
+                <div class="block_list">
+                  <p><?php echo _('An e-mail with instructions will be sent'); ?></p>
+                </div>
+              <?php else: ?>
+                <div><p><a href="index.php"><?php __('Return to login page'); ?></a></p></div>
+              <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</body>

--- a/bureau/admin/reset.php
+++ b/bureau/admin/reset.php
@@ -1,0 +1,15 @@
+<?php
+
+require_once("../class/config_nochk.php");
+
+if (isset($_GET['uid']) && isset($_GET['token']) && isset($_GET['timestamp'])) {
+    // We may have received a one-time use link.
+    $logged_in = $mem->temporary_login($_GET['uid'], $_GET['timestamp'],
+                                       $_GET['token']);
+    if ($logged_in) {
+        $msg->raise('INFO', 'admin/reset', _('Please change your password'));
+        header("Location: /mem_param.php");
+        exit;
+    }
+}
+header("Location: /index.php");


### PR DESCRIPTION
Allows a user to request a one-time login link send via e-mail. Once used, the user is logged in and is able to change their password once without requiring the old password to be submitted.

Highly inspired from how Drupal handles password reset with one-time login links.

Closes #102 
