### PR TITLE
user cron jobs that fall outside the max concurrent limit cause an error

### DIFF
--- a/bureau/class/m_cron.php
+++ b/bureau/class/m_cron.php
@@ -363,7 +363,7 @@ class m_cron {
                 // (it's important to do this before removing the old one)
                 if ($i < count($urls)) {
                     $ch = curl_init();
-                    $options[CURLOPT_URL] = $urls[$i++];  // increment i
+                    $options[CURLOPT_URL] = $urls[$i++]["url"];  // increment i
                     curl_setopt_array($ch, $options);
                     if (strtolower(substr($options[CURLOPT_URL], 0, 5)) == "https") {
                         curl_setopt($ch, CURLOPT_CAINFO, m_cron::DEFAULT_CAFILE);


### PR DESCRIPTION
The $urls variable is an array of arrays. There was a sub-element access
that was left out in the part of the rolling_curl function that starts
user cron jobs that are waiting in queue because there were too many
cron jobs to process at once.

Arguably the code that starts a curl request should be split out into a
function and reused, but that change is more complex than a one-line fix
to an actual bug.