### PR TITLE
Order enumerated mails for a domain by ascending alphabetic order

### DIFF
--- a/bureau/class/m_mail.php
+++ b/bureau/class/m_mail.php
@@ -309,7 +309,7 @@ ORDER BY
         }
         $db->query("SELECT a.id, a.address, a.password, a.`enabled`, a.mail_action, d.domaine AS domain, m.quota, m.quota*1024*1024 AS quotabytes, q.quota_dovecot as used, NOT ISNULL(m.id) AS islocal, a.type, r.recipients, m.lastlogin, a.domain_id
          FROM ((domaines d, address a LEFT JOIN mailbox m ON m.address_id=a.id) LEFT JOIN dovecot_quota q ON CONCAT(a.address,'@',d.domaine)  = q.user) LEFT JOIN recipient r ON r.address_id=a.id
-         WHERE " . $where . " AND d.id=a.domain_id " . $limit . " ;", $query_args);
+         WHERE " . $where . " AND d.id=a.domain_id ORDER BY a.address ASC " . $limit . " ;", $query_args);
         if (!$db->next_record()) {
             $msg->raise("ERROR", "mail", _("No email found for this query"));
             return array();


### PR DESCRIPTION
Fixes #341

When applying LIMIT X, Y the ordering before the limit and offset do
not seem to be guaranteed. For example, if you have a large number of
e-mail addresses, and you page between the same e-mail address can appear twice.

The case where this was happening there were 2-3 mail boxes and ~90 aliases.

I'm not sure if this tied somehow to the database version used, but making the
desired ordering explicit ensures that all mails will eventually be shown and
shouldn't be shown twice.