### PR TITLE
Matomo integration fixes

### DIFF
--- a/bureau/class/m_piwik.php
+++ b/bureau/class/m_piwik.php
@@ -118,7 +118,7 @@ class m_piwik {
             if ($api_data->result === 'success') {
                 $user = $this->get_user($user_login);
                 $user_creation_date = $user->date_registered;
-                $ret_value = $db->query("INSERT INTO piwik_users (uid, passwd, login, created_date) VALUES ( ?, ?, ?, ?);", array($cuid, md5('$user_pass'), $user_login, $user_creation_date));
+                $ret_value = $db->query("INSERT INTO piwik_users (uid, passwd, login, created_date) VALUES ( ?, ?, ?, ?);", array($cuid, md5($user_pass), $user_login, $user_creation_date));
                 return $ret_value;
             } else {
                 $msg->raise("ERROR", "piwik", $api_data->message);

--- a/bureau/class/m_piwik.php
+++ b/bureau/class/m_piwik.php
@@ -326,7 +326,8 @@ class m_piwik {
         $msg->debug("piwik","site_list");
 
         $this->get_alternc_sites();
-        $api_data = $this->call_privileged_page('API', 'SitesManager.getAllSites');
+        $api_data = $this->call_privileged_page('API', 'SitesManager.getAllSites',
+                                                array('filter_limit' => -1));
         $data = array();
 
         if($api_data) {
@@ -364,7 +365,8 @@ class m_piwik {
 
     function get_site_list()
     {
-        return $this->call_privileged_page('API', 'SitesManager.getAllSites');
+        return $this->call_privileged_page('API', 'SitesManager.getAllSites',
+                                           array('filter_limit' => -1));
     }
     // Ajoute un site à Piwik
     // can't figure out how to pass multiple url through the API


### PR DESCRIPTION
Two changes to fix some issues with Matomo integration

* Store the hash of the matomo user's password instead of a fixed string (Fixes part of #260)
* Request an unlimited number of results for the site lists. By default Matomo applies a limit of 100 results on API endpoints which return arrays.

Thanks,
Kienan