### PR TITLE
Fixes #337, #338, #349: Various corrections to DKIM

### DIFF
--- a/bureau/class/m_bind.php
+++ b/bureau/class/m_bind.php
@@ -218,7 +218,11 @@ class m_bind {
         global $db;
         $db->query("
         SELECT 
-          REPLACE(REPLACE(dt.entry,'%TARGET%',sd.valeur), '%SUB%', if(length(sd.sub)>0,sd.sub,'@')) AS ENTRY 
+          REPLACE(REPLACE(dt.entry,'%TARGET%',sd.valeur), '%SUB%', if(length(sd.sub)>0,sd.sub,'@')) AS ENTRY,
+          dt.target AS TARGET,
+          dt.entry  AS ORIGINAL_ENTRY,
+          sd.valeur AS VALEUR,
+          if(length(sd.sub)>0,sd.sub,'@') AS SUB
         FROM 
           sub_domaines sd,
           domaines_type dt 
@@ -229,7 +233,30 @@ class m_bind {
         ORDER BY ENTRY ;");
         $t="";
         while ($db->next_record()) {
-            $t.= $db->f('ENTRY')."\n";
+            // TXT entries may be longer than 255 characters, but need
+            // special treatment. @see https://kb.isc.org/docs/aa-00356
+            if (strlen($db->f('VALEUR')) >= 256 && $db->f('TARGET') == 'TXT') {
+                $chunks = str_split($db->f('VALEUR'), 255);
+                if ($chunks !== FALSE) {
+                    $new_entry = '';
+                    foreach ($chunks as $chunk) {
+                        $new_entry .= '"' . $chunk . '" ';
+                    }
+                    $new_entry = trim($new_entry, ' ');
+                    $entry = strtr($db->f('ORIGINAL_ENTRY'), array(
+                        '%SUB%' => $db->f('SUB'),
+                        // Don't want extra double quotes in this case
+                        '"%TARGET%"' => $new_entry,
+                    ));
+                }
+                else {
+                    $entry = $db->f('ENTRY');
+                }
+            }
+            else {
+                $entry = $db->f('ENTRY');
+            }
+            $t.= $entry . "\n";
         }
         return $t;
     }

--- a/bureau/class/m_mail.php
+++ b/bureau/class/m_mail.php
@@ -471,12 +471,12 @@ ORDER BY
         }
         $domain=$db->Record["domaine"];
         $db->query("UPDATE sub_domaines SET web_action='DELETE' WHERE domaine= ? AND (type='defmx' OR type='defmx2');", array($domain));
-        
+        $db->query("UPDATE sub_domaines SET web_action='DELETE' WHERE domaine= ? AND sub='alternc._domainkey';",array($domain));
+
         $this->del_dns_dmarc($domain);
         $this->del_dns_spf($domain);
         $this->del_dns_autoconf($domain);
-        $this->dkim_del($domain);
-        
+
         $db->query("UPDATE domaines SET dns_action='UPDATE' WHERE id= ? ;", array($dom_id));
         return true;
     }
@@ -1124,7 +1124,7 @@ ORDER BY
      */ 
     function del_dns_dmarc($domain) {
         global $db;
-        $db->query("UPDATE sub_domaines SET web_action='DELETE' WHERE domaine= ? AND type='txt' AND sub='' AND valeur LIKE 'v=dmarc1 %';", array($domain));
+        $db->query("UPDATE sub_domaines SET web_action='DELETE' WHERE domaine= ? AND type='txt' AND sub='_dmarc';", array($domain));
     }
     
 
@@ -1224,7 +1224,6 @@ ORDER BY
             del_line_from_file("/etc/opendkim/KeyTable","alternc._domainkey.".$domain." ".$domain.":alternc:/etc/opendkim/keys/".$domain."/alternc.private");
             del_line_from_file("/etc/opendkim/SigningTable",$domain." alternc._domainkey.".$domain);
         }
-        $db->query("DELETE FROM sub_domaines WHERE domaine=? AND sub='alternc._domainkey';",array($domain));
         // No need to do DNS_ACTION="UPDATE" => we are in the middle of a HOOK
     }
 

--- a/bureau/class/m_mail.php
+++ b/bureau/class/m_mail.php
@@ -1183,10 +1183,12 @@ ORDER BY
         if (!file_exists($target_dir.'/alternc.txt')) {
             $this->shouldreloaddkim=true;
             if (! is_dir($target_dir)) mkdir($target_dir); // create dir
-            // Generate the key, 1200 bits (better than 1024)
             $old_dir=getcwd();
             chdir($target_dir);
-            exec('opendkim-genkey -b 1200 -r -d '.escapeshellarg($domain).' -s "alternc" ');
+            // Generate the key, 2048 bits (better than 1024)
+            // 2048 bits is also the default in recent Debian builds of opendkim
+            // @see man opendkim-genkey
+            exec('opendkim-genkey -b 2048 -r -d '.escapeshellarg($domain).' -s "alternc" ');
             chdir($old_dir);
             // opendkim must be owner of the key
             chown("$target_dir/alternc.private", 'opendkim');

--- a/etc/alternc/templates/alternc/apache2.conf
+++ b/etc/alternc/templates/alternc/apache2.conf
@@ -14,6 +14,7 @@ AssignUserId www-data www-data
   Options +FollowSymLinks
   AllowOverride None
   Require all denied
+  Satisfy Any
 </Directory>
 #### End security parameters
 

--- a/install/mysql.sql
+++ b/install/mysql.sql
@@ -217,7 +217,7 @@ CREATE TABLE IF NOT EXISTS sub_domaines (
   compte int(10) unsigned NOT NULL default '0',
   domaine varchar(255) NOT NULL default '',
   sub varchar(255) NOT NULL default '',
-  valeur varchar(255) default NULL,
+  valeur varchar(1024) default NULL,
   type varchar(30) NOT NULL default 'LOCAL',
   web_action enum ('OK','UPDATE','DELETE') NOT NULL default 'UPDATE',
   web_result varchar(255) not null default '',

--- a/install/upgrades/3.5.0.3.sql
+++ b/install/upgrades/3.5.0.3.sql
@@ -1,0 +1,2 @@
+-- Increase size of sub_domaines valeur column. @see GH#337
+ALTER TABLE sub_domaines MODIFY COLUMN valeur VARCHAR(1024);


### PR DESCRIPTION
The default length of 255 is too short for many DKIM keys. I've chosen to set it to 1024 characters long, this should happily fit 4096 bit DKIM keys (which create entries ~870 characters long).