### PR TITLE
Fixes #370: Fix insert query failure during import_cert

### DIFF
--- a/bureau/class/m_ssl.php
+++ b/bureau/class/m_ssl.php
@@ -511,11 +511,13 @@ INSTR(CONCAT(sd.sub,IF(sd.sub!='','.',''),sd.domaine),'.')+1))=?
         $altnames = $this->parseAltNames($crtdata["extensions"]["subjectAltName"]);
 
         // Everything is PERFECT and has been thoroughly checked, let's insert those in the DB !
+        // The sslcsr column is required as it has no default value, giving it an empty value.
         $db->query(
-            "INSERT INTO certificates SET uid=?, status=?, fqdn=?, altnames=?, validstart=FROM_UNIXTIME(?), validend=FROM_UNIXTIME(?), sslkey=?, sslcrt=?, sslchain=?, provider=?;",
+            "INSERT INTO certificates SET uid=?, status=?, fqdn=?, altnames=?, validstart=FROM_UNIXTIME(?), validend=FROM_UNIXTIME(?), sslkey=?, sslcrt=?, sslchain=?, provider=?, sslcsr = '';",
             array($cuid, self::STATUS_OK, $fqdn, $altnames, intval($validstart), intval($validend), $key, $crt, $chain, $provider)
         );
         if (!($id = $db->lastid())) {
+            $msg->log('ssl', 'impoert_cert', 'insert query failed (' . print_r($db->last_error(), TRUE) . ')');
             $msg->raise("ERROR","ssl", _("Can't save the Key/Crt/Chain now. Please try later."));
             return false;
         }


### PR DESCRIPTION
The sslcsr is just set to an empty string so that the query works properly.
Without it, queries fail since sslcsr does not have a default value set.

Improved the detail of the messages logged during the failure of that query as well.