### PR TITLE
Fixes #380: Add sftp support to proftpd

### DIFF
--- a/etc/alternc/templates/proftpd/conf.d/sftp.conf
+++ b/etc/alternc/templates/proftpd/conf.d/sftp.conf
@@ -1,0 +1,44 @@
+<VirtualHost 0.0.0.0>
+    SFTPEngine on
+    Port 2222
+    SFTPLog /var/log/proftpd/sftp.log
+
+    SFTPOptions AllowInsecureLogin
+    SFTPAuthMethods password
+
+    # database@host:port login password
+    SQLConnectInfo                  %%dbname%%@%%dbhost%%:3306 %%dbuser%% %%dbpwd%%
+    # Table :
+    SQLUserInfo ftpusers name encrypted_password uid uid homedir NULL
+
+    # Use mysql PASSWORD function
+    SQLAuthTypes                    Crypt
+    # Only mysql authentication enabled
+    SQLAuthenticate users
+
+    SQLDefaultGID                   33
+    SQLDefaultUID                   33
+    # Minimum ID allowed to log in. Other users should use SFTP
+    SQLMinID                        33
+    # We don't use Unix rights managment on AlternC, so let's hide real owner/group/rights
+    DirFakeGroup    on alternc
+    DirFakeUser     on ~
+
+    # Host keys, for server host authentication
+    SFTPHostKey /etc/ssh/ssh_host_dsa_key
+    SFTPHostKey /etc/ssh/ssh_host_rsa_key
+    SFTPHostKey /etc/ssh/ssh_host_ecdsa_key
+
+    <Directory /*>
+        DenyAll
+    </Directory>
+
+    <Directory /var/www/alternc/>
+        Umask                         022  022
+        AllowOverwrite                on
+        AllowAll
+        <Limit SITE_CHMOD>
+        AllowAll
+        </Limit>
+    </Directory>
+</Virtualhost>

--- a/etc/alternc/templates/proftpd/modules.conf
+++ b/etc/alternc/templates/proftpd/modules.conf
@@ -27,6 +27,7 @@ LoadModule mod_sql_mysql.c
 #LoadModule mod_radius.c
 LoadModule mod_wrap.c
 LoadModule mod_rewrite.c
+LoadModule mod_sftp.c
 
 # keep this module the last one
 LoadModule mod_ifsession.c

--- a/etc/alternc/templates/proftpd/proftpd.conf
+++ b/etc/alternc/templates/proftpd/proftpd.conf
@@ -154,3 +154,10 @@ RLimitChroot off
        TLSOptions NoSessionReuseRequired 
 
 </IfModule>
+
+# Include other custom configuration files
+# !! Please note, that this statement will read /all/ file from this subdir,
+# i.e. backup files created by your editor, too !!!
+# Eventually create file patterns like this: /etc/proftpd/conf.d/*.conf
+#
+Include /etc/proftpd/conf.d/*.conf

--- a/install/alternc.install
+++ b/install/alternc.install
@@ -129,7 +129,7 @@ if [ -d /etc/postfix ]; then
                   etc/opendkim.conf etc/default/opendkim"
 fi
 if [ -e /etc/proftpd/proftpd.conf ]; then
-    CONFIG_FILES="$CONFIG_FILES etc/proftpd/proftpd.conf etc/proftpd/welcome.msg etc/proftpd/modules.conf"
+    CONFIG_FILES="$CONFIG_FILES etc/proftpd/proftpd.conf etc/proftpd/welcome.msg etc/proftpd/modules.conf etc/proftpd/conf.d/sftp.conf"
 fi
 
 if [ -e /etc/default/saslauthd ]; then


### PR DESCRIPTION
Solve #300 

Add sftp support to proftp.
Port is hardcoded to 2222, easy to change with updating template file