### PR TITLE
Add default vhost before the admistration panel

### DIFF
--- a/etc/alternc/default-vhost.conf
+++ b/etc/alternc/default-vhost.conf
@@ -1,0 +1,16 @@
+<VirtualHost *:80>
+	#basic default name, as otherwise the default taken will be the FQDN of the server, and that is not what we want
+	ServerName default.alternc
+    DocumentRoot /etc/alternc/default-vhost/
+
+	#we want to redirect all requests to our default index.html page, except, obviously, the index.html request
+	<Directory "/etc/alternc/default-vhost/">
+		ErrorDocument 404 /index.html
+		RedirectMatch 404 ^(!index.html)$
+		Allow from all
+	</Directory>
+
+  ErrorLog ${APACHE_LOG_DIR}/other_vhosts_error.log
+  CustomLog ${APACHE_LOG_DIR}/other_vhosts_access.log combined
+
+</VirtualHost>

--- a/etc/alternc/default-vhost/index.html
+++ b/etc/alternc/default-vhost/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Site Maintenance</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no">
+    <style>
+  body { text-align: center; padding: 100px; }
+  body { font: 1.2em Helvetica, sans-serif; color: #333; }
+  article { display: block; text-align: left; max-width: 800px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+    </style>
+  </head>
+  <body>
+    <article>
+      <h1>Site web en maintenance</h1>
+      <div>
+        <p>Nous nous excusons pour la gêne occasionnée, nous sommes en train d'effectuer des opérations de maintenance sur ce site web. Merci de votre compréhension !</p>
+				<p>Pour toute question, ou si ce message persiste, merci de contacter votre administrateur système.</p>
+      </div>
+    </article>
+    <article>
+      <h1>Website currently offline</h1>
+      <div>
+        <p>Sorry for the inconvenience but we're performing some maintenance at the moment. We'll be back online shortly!</p>
+				<p>For any question, or if this message stays too long, please contact your system administrator.</p>
+      </div>
+    </article>
+  </body>
+</html>
+

--- a/etc/alternc/templates/alternc/apache2.conf
+++ b/etc/alternc/templates/alternc/apache2.conf
@@ -70,6 +70,9 @@ ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/
 </Directory>
 
 <VirtualHost *:80>
+  Include /etc/alternc/default-vhost.conf
+</VirtualHost>
+<VirtualHost *:80>
   Include /etc/alternc/bureau.conf
 </VirtualHost>
 

--- a/install/alternc.install
+++ b/install/alternc.install
@@ -116,7 +116,7 @@ TEMPLATE_DIR="/etc/alternc/templates"
 
 # Find needed configuration files (without the initial '/')
 # replace this one unconditionnally
-CONFIG_FILES="etc/alternc/bureau.conf etc/alternc/default-vhost.conf etc/apache2/envvars etc/alternc/apache2.conf etc/alternc/phpmyadmin.inc.php"
+CONFIG_FILES="etc/alternc/bureau.conf etc/apache2/envvars etc/alternc/apache2.conf etc/alternc/phpmyadmin.inc.php"
 
 if [ -e /etc/bind/named.conf ]; then
     CONFIG_FILES="$CONFIG_FILES etc/bind/named.conf.options"

--- a/install/alternc.install
+++ b/install/alternc.install
@@ -116,7 +116,7 @@ TEMPLATE_DIR="/etc/alternc/templates"
 
 # Find needed configuration files (without the initial '/')
 # replace this one unconditionnally
-CONFIG_FILES="etc/alternc/bureau.conf etc/apache2/envvars etc/alternc/apache2.conf etc/alternc/phpmyadmin.inc.php"
+CONFIG_FILES="etc/alternc/bureau.conf etc/alternc/default-vhost.conf etc/apache2/envvars etc/alternc/apache2.conf etc/alternc/phpmyadmin.inc.php"
 
 if [ -e /etc/bind/named.conf ]; then
     CONFIG_FILES="$CONFIG_FILES etc/bind/named.conf.options"


### PR DESCRIPTION
I believe that we should not display the administration panel in case someone is redirected to the server with a faulty dns name.
So far, the default virtual host showed is the administration panel one, but we should rather show an error message / maintenance mode message.
I have some doubt about the installation files, I'm not sure if all content of /etc/alternc directory is copied into the /etc/alternc directory on the machine, I have based my code on that belief, but I'd be glad to chage it if it is faulty / breaking.
