### PR TITLE
Fixes #394: Remove trailing '.' from the return values of m_dom::whois()

### DIFF
--- a/bureau/class/m_dom.php
+++ b/bureau/class/m_dom.php
@@ -956,7 +956,23 @@ class m_dom {
         $ns=array();
         foreach($out as $line) {
             if (preg_match('#^'.str_replace(".","\\.",$domain).'\..*IN\s*NS\s*(.*)$#',$line,$mat)) {
-                $ns[]=trim($mat[1]);
+                $n = trim($mat[1]);
+                # If the nameserver ends with a '.', we want to remove it as callers of
+                # this function expect the fully qualified domain name without a trailing
+                # dot.
+                if (substr($n, -1) == '.') {
+                    $ns[] = substr($n, 0, strlen($n)-1);
+                }
+                else {
+                    # In the case where is no trailing dot, the normal procedure is to append
+                    # the domain name to finish qualifying the answer.
+                    # eg. If one searches for example.com and gets a result "ns", then
+                    # the fully qualified answer is 'ns.example.com'.
+                    #
+                    # I'm not sure in what case dig will return a non-fully qualified answer.
+                    #  - Kienan 2019-12-17
+                    $ns[] = $n . '.' . $domain;
+                }
             }
         }
         return $ns;

--- a/phpunit/tests/bureau/class/m_domTest.php
+++ b/phpunit/tests/bureau/class/m_domTest.php
@@ -349,9 +349,12 @@ class m_domTest extends TestCase
     public function testWhois()
     {
         // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-          'This test has not been implemented yet.'
+        $ns = $this->object->whois('alternc.org');
+        $expected_ns = array(
+            'primary.heberge.info',
+            'secondary.heberge.info',
         );
+        $this->assertSame($ns, $expected_ns);
     }
 
     /**


### PR DESCRIPTION
The answer from dig is typically fully qualified with a trailing '.',
but the callers of whois() expect the nameservers without that trailing dot.