### PR TITLE
Use Breaks instead of Conflicts with alternc-ssl and alternc-admintools

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -70,12 +70,12 @@ Recommends: default-mysql-server | mysql-server | mariadb-server
           , unzip
           , bzip2
 	  , alternc-certificate-provider-letsencrypt
-Conflicts: alternc-admintools
-        , alternc-awstats (<< 1.0)
+Breaks: alternc-admintools
+      , alternc-ssl
+Conflicts: alternc-awstats (<< 1.0)
         , alternc-webalizer (<= 0.9.4)
         , alternc-mailman (<< 2.0)
         , courier-authlib
-        , alternc-ssl
 Provides: alternc-admintools
         , alternc-ssl
 Replaces: alternc-admintools


### PR DESCRIPTION
This follows the Debian policy on using Breaks when moving files from one
package to another.

@see https://www.debian.org/doc/debian-policy/ch-relationships.html#conflicting-binary-packages-conflicts

If apt/apt-get are used to install the new package, it will know to automatically
remove alternc-ssl (or alternc-admintools) instead of refusing to proceed at all.

Refs #374 