### PR TITLE
Fixes #399: Hide non-alternc matomo users for site permissions

### DIFF
--- a/bureau/class/m_piwik.php
+++ b/bureau/class/m_piwik.php
@@ -165,6 +165,12 @@ class m_piwik {
                     $api_data->$user = 'noaccess';
                 }
             }
+            # Hide users who have access, but are not in AlternC
+            foreach (get_object_vars($api_data) as $user => $access) {
+                if (!in_array($user, $this->alternc_users)) {
+                    unset($api_data->$user);
+                }
+            }
             return $api_data;
         }
         else return FALSE;

--- a/bureau/class/m_piwik.php
+++ b/bureau/class/m_piwik.php
@@ -161,13 +161,13 @@ class m_piwik {
         if ($api_data !== FALSE) {
             $api_data = $api_data[0]; // Data is in the first column
             foreach ($this->alternc_users AS $key=>$user) {
-                if (!array_key_exists($user, $api_data)) {                                                            
-                    $api_data->$user = 'noaccess';                                                                
-                } 
+                if (!array_key_exists($user, $api_data)) {
+                    $api_data->$user = 'noaccess';
+                }
             }
             return $api_data;
         }
-        else return FALSE; 
+        else return FALSE;
     }
 
 


### PR DESCRIPTION
Users made in the Matomo interface and given an access to a site
that's in AlternC show up without this restriction. When that happens,
the user is no longer able to modify permissions for any of the Matomo
users from their AlternC account.