### PR TITLE
Fix postfix sql queries

### DIFF
--- a/api/panel/bootstrap.php
+++ b/api/panel/bootstrap.php
@@ -70,6 +70,7 @@ if (is_file($root."/class/variables.php")) {
 }
 $mem=new m_mem();
 $err=new m_err();
+$msg=new m_messages();
 $authip=new m_authip();
 $hooks=new m_hooks();
 

--- a/etc/alternc/templates/opendkim.conf
+++ b/etc/alternc/templates/opendkim.conf
@@ -14,3 +14,7 @@ KeyTable           /etc/opendkim/KeyTable
 SigningTable       /etc/opendkim/SigningTable
 ExternalIgnoreList /etc/opendkim/TrustedHosts
 InternalHosts      /etc/opendkim/TrustedHosts
+
+# The value from /etc/default/opendkim doesn't seem to be taken into account
+# @see https://bugs.debian.org/cgi-bin/bugreport.cgi?archive=no&bug=861169
+Socket             local:/var/run/opendkim/opendkim.sock

--- a/etc/alternc/templates/postfix/mymail2mail.cf
+++ b/etc/alternc/templates/postfix/mymail2mail.cf
@@ -8,6 +8,6 @@ user = %%db_mail_user%%
 password = %%db_mail_pwd%%
 hosts =%%dbhost%%
 dbname = %%dbname%%
-query = select concat(`address`.`address`,'@',`domaines`.`domaine`) AS `mail` from address,domaines where `address`.`enabled` = 1 and `address`.`domain_id` = domaines.id and concat(`address`.`address`,'@',`domaines`.`domaine`) = '%s';
+query = select concat(`address`.`address`,'@',`domaines`.`domaine`) AS `mail` from address,domaines where `address`.`enabled` = 1 and `address`.`domain_id` = domaines.id and concat(`address`.`address`,'@',`domaines`.`domaine`) = '%s' and domaines.gesmx=1;
  
 

--- a/etc/alternc/templates/postfix/mytransport.cf
+++ b/etc/alternc/templates/postfix/mytransport.cf
@@ -7,6 +7,6 @@ password = %%db_mail_pwd%%
 hosts =%%dbhost%%
 dbname = %%dbname%%
 
-query = SELECT delivery FROM mailbox JOIN address ON address.id = mailbox.address_id JOIN domaines ON domaines.id = address.domain_id WHERE address.address=SUBSTRING_INDEX('%s','@',1) AND domaines.domaine=SUBSTRING_INDEX('%s','@',-1)
+query = SELECT delivery FROM mailbox JOIN address ON address.id = mailbox.address_id JOIN domaines ON domaines.id = address.domain_id WHERE address.address=SUBSTRING_INDEX('%s','@',1) AND domaines.domaine=SUBSTRING_INDEX('%s','@',-1) AND domaines.gesmx=1
 
 

--- a/etc/alternc/templates/postfix/myvirtual.cf
+++ b/etc/alternc/templates/postfix/myvirtual.cf
@@ -6,5 +6,5 @@ user = %%db_mail_user%%
 password = %%db_mail_pwd%%
 hosts =%%dbhost%%
 dbname = %%dbname%%
-query = select concat(path, '/Maildir/') from mailbox join address on address.id = mailbox.address_id join domaines on domaines.id = address.domain_id where concat(address.address,'@',domaines.domaine) ='%s';
+query = select concat(path, '/Maildir/') from mailbox join address on address.id = mailbox.address_id join domaines on domaines.id = address.domain_id where concat(address.address,'@',domaines.domaine) ='%s' and domaines.gesmx=1;
 

--- a/install/alternc.install
+++ b/install/alternc.install
@@ -595,6 +595,15 @@ touch /etc/opendkim/TrustedHosts /etc/opendkim/SigningTable /etc/opendkim/KeyTab
 grep -q "^127.0.0.1\$" /etc/opendkim/TrustedHosts || echo "127.0.0.1" >>/etc/opendkim/TrustedHosts
 grep -q "^localhost\$" /etc/opendkim/TrustedHosts || echo "localhost" >>/etc/opendkim/TrustedHosts
 grep -q "^$PUBLIC_IP\$" /etc/opendkim/TrustedHosts || echo "$PUBLIC_IP" >>/etc/opendkim/TrustedHosts
+if [ "$(lsb_release -s -c)" == 'stretch' ] ; then
+    /lib/opendkim/opendkim.service.generate
+    # Without adding '-u opendkim' after the service file is generated, opendkim
+    # will run as root, which we do not want.
+    if [ "$(grep -c 'u opendkim' /etc/systemd/system/opendkim.service.d/override.conf)" == 0 ] ; then
+        sed 's/inet:8891@127.0.0.1/& -u opendkim/' /etc/systemd/system/opendkim.service.d/override.conf
+    fi
+    systemctl daemon-reload
+fi
 
 # Add opendkim to service to restart
 SERVICES="$SERVICES opendkim"

--- a/install/alternc.install
+++ b/install/alternc.install
@@ -600,7 +600,7 @@ if [ "$(lsb_release -s -c)" == 'stretch' ] ; then
     # Without adding '-u opendkim' after the service file is generated, opendkim
     # will run as root, which we do not want.
     if [ "$(grep -c 'u opendkim' /etc/systemd/system/opendkim.service.d/override.conf)" == 0 ] ; then
-        sed 's/inet:8891@127.0.0.1/& -u opendkim/' /etc/systemd/system/opendkim.service.d/override.conf
+        sed -i -e 's/inet:8891@127.0.0.1/& -u opendkim/' /etc/systemd/system/opendkim.service.d/override.conf
     fi
     systemctl daemon-reload
 fi

--- a/lib/Alternc/Api/Object/Domain.php
+++ b/lib/Alternc/Api/Object/Domain.php
@@ -169,6 +169,10 @@ class Alternc_Api_Object_Domain extends Alternc_Api_Legacyobject {
         }
     }
 
+    
+
+
+    
 }
 
 // class Alternc_Api_Object_Domain

--- a/lib/Alternc/Api/Object/Subdomain.php
+++ b/lib/Alternc/Api/Object/Subdomain.php
@@ -15,7 +15,7 @@ class Alternc_Api_Object_Subdomain extends Alternc_Api_Legacyobject {
 
     /** API Method from legacy class method dom->get_sub_domain_all($dom)
      * @param $options a hash with parameters transmitted to legacy call
-     * musr be the subdomain id ID
+     * must be the subdomain id ID
      * @return Alternc_Api_Response whose content is the list of subdomains on this server 
      */
     function get($options) {
@@ -48,18 +48,19 @@ class Alternc_Api_Object_Subdomain extends Alternc_Api_Legacyobject {
     /** API Method from legacy class method dom->set_sub_domain($dom)
      * @param $options a hash with parameters transmitted to legacy call
      * must be $dom, $sub, $type, $dest and could be $sub_domain_id 
+     * and $urgent
      * @return Alternc_Api_Response whose content is true or false 
      * if the change has been made
      */
     function set($options) {
-        global $cuid;
+        global $cuid,$L_INOTIFY_UPDATE_DOMAIN;
         if ($this->isAdmin) {
             if (isset($options["uid"])) {
                 $cuid = intval($options["uid"]);
             }
         }
         $mandatory = array("dom", "sub", "type", "dest");
-        $defaults = array("sub_domain_id" => null);
+        $defaults = array("sub_domain_id" => null, "urgent" =>false);
         $missing = "";
         foreach ($mandatory as $key) {
             if (!isset($options[$key])) {
@@ -80,6 +81,50 @@ class Alternc_Api_Object_Subdomain extends Alternc_Api_Legacyobject {
         if (!$did) {
             return $this->alterncLegacyErrorManager();
         } else {
+            if ($options["urgent"])
+                touch($L_INOTIFY_UPDATE_DOMAIN);            
+            return new Alternc_Api_Response(array("content" => $did));
+        }
+    }
+
+    
+    /** API Method from legacy class method dom->del_by_id($domid)
+     * @param $options a hash with parameters transmitted to legacy call
+     * must be $id (may be $urgent)
+     * @return Alternc_Api_Response whose content is true or false 
+     * if the change has been made
+     */
+    function del_by_id($options) {
+        global $cuid,$L_INOTIFY_UPDATE_DOMAIN;
+        if ($this->isAdmin) {
+            if (isset($options["uid"])) {
+                $cuid = intval($options["uid"]);
+            }
+        }
+        $mandatory = array("id");
+        $defaults = array("urgent" =>false);
+        $missing = "";
+        foreach ($mandatory as $key) {
+            if (!isset($options[$key])) {
+                $missing.=$key . " ";
+            }
+        }
+        foreach ($defaults as $key => $value) {
+            if (!isset($options[$key])) {
+                $options[$key] = $value;
+            }
+        }
+        if ($missing) {
+            return new Alternc_Api_Response(array("code" => self::ERR_INVALID_ARGUMENT, "message" => "Missing or invalid argument: " . $missing));
+        }
+        $this->dom->lock();
+        $did = $this->dom->del_sub_domain($options["id"]);
+        $this->dom->unlock();
+        if (!$did) {
+            return $this->alterncLegacyErrorManager();
+        } else {
+            if ($options["urgent"])
+                touch($L_INOTIFY_UPDATE_DOMAIN);            
             return new Alternc_Api_Response(array("content" => $did));
         }
     }


### PR DESCRIPTION
Nous avions rencontré un problème lors d'une migration, car un proxy mail plantait dû à des addresses trouvées dans l'alternC, alors que nous ne gérions pas les mail pour ce domaine.
Les précisions apportées permettent d'éviter ce genre d'écueil