### PR TITLE
Fix #413: Add return values for bind update domains hooks

### DIFF
--- a/bureau/class/m_bind.php
+++ b/bureau/class/m_bind.php
@@ -68,7 +68,7 @@ class m_bind {
             $serial=date("Ymd")."00";
             $islocked=false;
         }
-        if ($islocked) return;
+        if ($islocked) return 1;
 
         // Prepare a new zonefile from a template
         $zone = file_get_contents($this->ZONE_TEMPLATE);
@@ -117,6 +117,7 @@ class m_bind {
         } else {
             $this->shouldreload=true;
         }
+        return 0;
     }
 
 
@@ -141,9 +142,10 @@ class m_bind {
         ) {
             $this->shouldreconfig=true;
         } else {
-            return;
+            return 0;
         }
         @unlink($this->zone_file_directory."/".$domain);
+        return 0;
     }
 
     


### PR DESCRIPTION
hook_updatedomains_dns_{add,del} have their return values checked in
m_dom::update_domains() to set the dns_result column.

When no return value is specified, the value is actually NULL and doesn't
get mapped to an integer value that is expected by the dns_result column.

As a result, the query fails silently and the DNS_ACTION column is never
updated. This causes update_domains to retry the same modification on
every run.

Note: 0/1 is used instead of TRUE/FALSE since the original code expects
integer return values from a shell script.