### PR TITLE
The variable used to interpolate domaine names should be @@DOMAIN@@

### DIFF
--- a/bureau/class/m_bind.php
+++ b/bureau/class/m_bind.php
@@ -88,7 +88,7 @@ class m_bind {
             "@@ns2@@" => "$L_NS2_HOSTNAME",
             "@@DEFAULT_MX@@" => "$L_DEFAULT_MX",
             "@@DEFAULT_SECONDARY_MX@@" => "$L_DEFAULT_SECONDARY_MX",
-            "@@DOMAINE@@" => $domain,
+            "@@DOMAIN@@" => $domain,
             "@@SERIAL@@" => $serial,
             "@@PUBLIC_IP@@" => "$L_PUBLIC_IP",
             "@@PUBLIC_IPV6@@" => "$L_PUBLIC_IPV6",

--- a/etc/alternc/templates/bind/templates/slave.template
+++ b/etc/alternc/templates/bind/templates/slave.template
@@ -1,1 +1,1 @@
-zone "@@DOMAINE@@" { type slave; allow-query { any; }; file "@@DOMAINE@@"; masters { %%public_ip%%; }; };
+zone "@@DOMAIN@@" { type slave; allow-query { any; }; file "@@DOMAIN@@"; masters { %%public_ip%%; }; };

--- a/install/domaines.template
+++ b/install/domaines.template
@@ -1,1 +1,1 @@
-zone "@@DOMAINE@@" { type slave; allow-query { any; }; file "@@DOMAINE@@"; masters { %%public_ip%%; }; };
+zone "@@DOMAIN@@" { type slave; allow-query { any; }; file "@@DOMAIN@@"; masters { %%public_ip%%; }; };


### PR DESCRIPTION
Both FR and EN spellings existed before this commit: `@@DOMAINE@@` and `@@DOMAIN@@` (see below).

I propose to use only one, the EN version.

On a server upgraded from 3.3.11 to 3.5.rc2 it caused zones to contain `@@DOMAINE@@`

_Occurences of `@@DOMAIN@@`_
```
$ gr @@DOMAIN@@
bureau/class/m_bind.php
111:                    "@@DOMAIN@@" => $domain,
137:                    "@@DOMAIN@@" => $domain,

etc/alternc/templates/bind/templates/named.template
1:zone "@@DOMAIN@@" { type master; file "@@ZONE_FILE@@"; allow-query { any; }; };
```

_Occurences of `@@DOMAIN@@`_
```
$ gr @@DOMAINE@@
install/domaines.template
1:zone "@@DOMAINE@@" { type slave; allow-query { any; }; file "@@DOMAINE@@"; masters { %%public_ip%%; }; };

bureau/class/m_bind.php
91:            "@@DOMAINE@@" => $domain,

etc/alternc/templates/bind/templates/zone.template
3:; BIND data file for domain @@DOMAINE@@

etc/alternc/templates/bind/templates/slave.template
1:zone "@@DOMAINE@@" { type slave; allow-query { any; }; file "@@DOMAINE@@"; masters { %%public_ip%%; }; };
```