### PR TITLE
Fixes #424: Watch a different directory for incrond actions by default

### DIFF
--- a/debian/alternc.postinst
+++ b/debian/alternc.postinst
@@ -114,10 +114,10 @@ SQLBACKUP_OVERWRITE=""
 ALTERNC_SLAVES=""
 
 # File to look at for forced launch of update_domain (use incron)
-INOTIFY_UPDATE_DOMAIN="/run/alternc/inotify_update_domain.lock"
+INOTIFY_UPDATE_DOMAIN="/run/alternc/incron/inotify_update_domain.lock"
 
 # File to look at for forced launch of do_actions (use incron)
-INOTIFY_DO_ACTION="/run/alternc/inotify_do_action.lock"
+INOTIFY_DO_ACTION="/run/alternc/incron/inotify_do_action.lock"
 
 # AlternC Locations
 ALTERNC_HTML=""
@@ -253,6 +253,7 @@ NFS_QUOTA=no" >> $CONFIGFILE
     chown root:bind /var/lib/alternc/bind/automatic.conf /var/lib/alternc/bind/slaveip.conf
     chmod 640       /var/lib/alternc/bind/automatic.conf /var/lib/alternc/bind/slaveip.conf
     mkdir -p /run/alternc && chown alterncpanel:alterncpanel /run/alternc
+    mkdir -p /run/alternc/incron && chown alterncpanel::alterncpanel /run/alternc/incron
     touch /run/alternc/refresh_slave
     /usr/lib/alternc/slave_dns
     # Apache will not start without this file

--- a/debian/alternc.postinst
+++ b/debian/alternc.postinst
@@ -253,7 +253,7 @@ NFS_QUOTA=no" >> $CONFIGFILE
     chown root:bind /var/lib/alternc/bind/automatic.conf /var/lib/alternc/bind/slaveip.conf
     chmod 640       /var/lib/alternc/bind/automatic.conf /var/lib/alternc/bind/slaveip.conf
     mkdir -p /run/alternc && chown alterncpanel:alterncpanel /run/alternc
-    mkdir -p /run/alternc/incron && chown alterncpanel::alterncpanel /run/alternc/incron
+    mkdir -p /run/alternc/incron && chown alterncpanel:alterncpanel /run/alternc/incron
     touch /run/alternc/refresh_slave
     /usr/lib/alternc/slave_dns
     # Apache will not start without this file

--- a/etc/incron.d/alternc_do_action
+++ b/etc/incron.d/alternc_do_action
@@ -1,1 +1,1 @@
-/run/alternc/incron/ IN_CREATE,IN_ATTRIB,IN_NO_LOOP /usr/lib/alternc/inotify_do_actions.sh
+/run/alternc/incron/inotify_do_action.lock IN_CREATE,IN_ATTRIB,IN_NO_LOOP /usr/lib/alternc/inotify_do_actions.sh

--- a/etc/incron.d/alternc_do_action
+++ b/etc/incron.d/alternc_do_action
@@ -1,1 +1,1 @@
-/run/alternc/ IN_CREATE,IN_ATTRIB,IN_NO_LOOP /usr/lib/alternc/inotify_do_actions.sh
+/run/alternc/incron/ IN_CREATE,IN_ATTRIB,IN_NO_LOOP /usr/lib/alternc/inotify_do_actions.sh

--- a/etc/incron.d/alternc_update_domains
+++ b/etc/incron.d/alternc_update_domains
@@ -1,1 +1,1 @@
-/run/alternc/ IN_CREATE,IN_ATTRIB,IN_NO_LOOP /usr/lib/alternc/inotify_update_domains.sh
+/run/alternc/incron/ IN_CREATE,IN_ATTRIB,IN_NO_LOOP /usr/lib/alternc/inotify_update_domains.sh

--- a/etc/incron.d/alternc_update_domains
+++ b/etc/incron.d/alternc_update_domains
@@ -1,1 +1,1 @@
-/run/alternc/incron/ IN_CREATE,IN_ATTRIB,IN_NO_LOOP /usr/lib/alternc/inotify_update_domains.sh
+/run/alternc/incron/inotify_update_domain.lock IN_CREATE,IN_ATTRIB,IN_NO_LOOP /usr/lib/alternc/inotify_update_domains.sh


### PR DESCRIPTION
This should help with #424 by switching the watched directories to a
sub-directory of /run/alternc. There are many other scripts create and
handle files in the /run/alternc that were causing incrond to start up
quite often.