### PR TITLE
Fixes #433: Fix warning when a user has many scheduled tasks to run

### DIFF
--- a/bureau/class/m_cron.php
+++ b/bureau/class/m_cron.php
@@ -363,7 +363,7 @@ class m_cron {
                 // (it's important to do this before removing the old one)
                 if ($i < count($urls)) {
                     $ch = curl_init();
-                    $options[CURLOPT_URL] = $urls[$i++];  // increment i
+                    $options[CURLOPT_URL] = $urls[$i++]['url'];  // increment i
                     curl_setopt_array($ch, $options);
                     if (strtolower(substr($options[CURLOPT_URL], 0, 5)) == "https") {
                         curl_setopt($ch, CURLOPT_CAINFO, m_cron::DEFAULT_CAFILE);


### PR DESCRIPTION
When a user has more than m_cron::MAX_SOCKETS actions to run when the
cron script is invoked, it uses a rolling window while running the
batch execution in CURL. The following warning happens because the
url key isn't being used when getting the information out of the array.