### PR TITLE
Fixes #415: Add upgrade notice when installing 3.5 if upgrading from a version less than 3.3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ This project native language is French, and the code is commented in English. Th
 
 [Pour installer AlternC, merci de suivre la documentation d'installation](https://alternc.com/Install-fr)
 
-### Upgrading from AlternC 3.[1,2,3].11
+### Upgrading from AlternC 3.[1,2,3].11 or earlier
+
+The recommended process for upgrading is to upgrade to 3.3.12 before upgrading to 3.5. If
+you choose to upgrade directly to 3.5 from an earlier version, please read this information
+as there is a risk of a loss of data.
 
 AlternC >= 3.5 removes integrates alternc-ssl and alternc-admintools in the the core AlternC package.
 

--- a/debian/alternc.preinst
+++ b/debian/alternc.preinst
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-
 . /usr/share/debconf/confmodule
 
 # Create AlternC Panel user for web server
@@ -64,6 +63,15 @@ case "$1" in
             echo "/etc/bind/master was not empty. Please remove it manually."
     fi
 
+    if dpkg --compare-versions "$2" lt "3.3.12"; then
+        db_input high alternc/confirm_unsupported_upgrade
+        db_go
+        db_get alternc/confirm_unsupported_upgrade
+        if [ "$RET" == "false" ] ; then
+           echo "User chose to abort installation" >&2
+           exit 1
+        fi
+    fi
     ;;
 
   abort-upgrade)

--- a/debian/alternc.templates
+++ b/debian/alternc.templates
@@ -264,3 +264,12 @@ _Description: Remote mysql: connection error
  .
  This is a fatal error and will cause the package installation
  to fail.
+
+Template: alternc/confirm_unsupported_upgrade
+Type: boolean
+_Description: This upgrade may incur data loss. Continue anyway?
+ When upgrading from AlternC < 3.3.12 to AlternC 3.5, sub domains
+ with SSL will be lost. It is recommended to upgrade to 3.3.12
+ before upgrading to 3.5.
+ .
+ If you chose to not continue, this package installation will fail.


### PR DESCRIPTION
Since the upgrade incurs data loss if the user has alternc-ssl installed, we attempt to warn the user before continuing with the upgrade.