### PR TITLE
Do not re-create sub_domaines unique key compte

### DIFF
--- a/install/upgrades/3.5.0.3.sql
+++ b/install/upgrades/3.5.0.3.sql
@@ -1,3 +1,1 @@
-alter table sub_domaines drop index compte;
-alter table sub_domaines add UNIQUE (compte,domaine,sub,type,valeur,web_action);
-
+DROP INDEX IF EXISTS compte on `sub_domaines`;

--- a/install/upgrades/3.5.0.3.sql
+++ b/install/upgrades/3.5.0.3.sql
@@ -1,0 +1,3 @@
+alter table sub_domaines drop index compte;
+alter table sub_domaines add UNIQUE (compte,domaine,sub,type,valeur,web_action);
+


### PR DESCRIPTION
    New installations haven't had this unique key since 2014
    (d9e24d9703bd9d3c99353fcb98bac880b25db5f7) and only old
    installations passing through 3.1.0~a would have had it
    added.
    
    Given that the unique key constraint was never dropped during
    an AlternC upgrade, I think it should just be dropped here.
    
    Re-creating is problematic when merged with other recent changes
    because the length of both the key and column size are longer
    than what MySQL/MariaDB support.

See https://github.com/AlternC/AlternC/issues/435 and https://github.com/AlternC/AlternC/pull/392
