### PR TITLE
API: instantiate m_message for logging

### DIFF
--- a/api/panel/bootstrap.php
+++ b/api/panel/bootstrap.php
@@ -72,6 +72,7 @@ $mem=new m_mem();
 $err=new m_err();
 $authip=new m_authip();
 $hooks=new m_hooks();
+$msg = new m_messages();
 
 
 for($i=0;$i<count($classes);$i++) {


### PR DESCRIPTION
Without this global instance, nothing works during the bootstrap: all
calls to log() crash because the instance does not exist.

closes: #419