### PR TITLE
Api: clear expired tokens

### DIFF
--- a/lib/Alternc/Api/Service.php
+++ b/lib/Alternc/Api/Service.php
@@ -131,6 +131,10 @@ class Alternc_Api_Service {
         if (!$request instanceof Alternc_Api_Request)
             throw new \Exception("request must be an Alternc_Api_Request object", self::ERR_INVALID_ARGUMENT);
 
+        // Make sure that no expired tokens are present when we verify the
+        // validity of the given token
+        Alternc_Api_Token::clearExpired($this->db);
+
         // we set the token in the Service object, so that other classes can use it :) 
         $this->token = Alternc_Api_Token::tokenGet($request->token_hash, $this->db);
         if ($this->token instanceof Alternc_Api_Response)  // bad token

--- a/lib/Alternc/Api/Token.php
+++ b/lib/Alternc/Api/Token.php
@@ -126,6 +126,22 @@ class Alternc_Api_Token {
         return $s;
     }
 
+    /**
+     * Remove all expired tokens
+     * @param $db PDO a PDO object representing AlternC's database.
+     *
+     * @return NULL
+     */
+    public static function clearExpired($db) {
+        if (!($db instanceof PDO)) {
+            throw new \Exception("Parameter is not an instance of PDO.", self::ERR_DATABASE_ERROR);
+        }
+        $result = $db->query("DELETE FROM token WHERE expire < NOW()");
+        if ($result === FALSE) {
+            throw new \Exception("Database query failed: ". $db->Error);
+        }
+    }
+
 }
 
 // class Alternc_Api_Response


### PR DESCRIPTION
Currently the tokens have an expiration date but it is never checked and expired tokens are never cleared away.

This change takes care of this by removing all expired tokens before validating the one given to an API call. This way we can ensure that we won't permit access with expired tokens.

This pull request depends on #447 being merged.

Closes: #420 