### PR TITLE
Cleanup domain locks when an error occurs

### DIFF
--- a/bureau/admin/dom_doadd.php
+++ b/bureau/admin/dom_doadd.php
@@ -37,6 +37,7 @@ getFields($fields);
 $dom->lock();
 
 if (!$dom->add_domain($newdomain,$dns,0,0,$newisslave,$slavedom)) {
+	$dom->unlock();
 	include("dom_add.php");
 	exit();
 } else

--- a/bureau/admin/dom_subdoedit.php
+++ b/bureau/admin/dom_subdoedit.php
@@ -49,6 +49,7 @@ $dom->lock();
 
 $dt=$dom->domains_type_lst();
 if ( (!isset($isinvited) || !$isinvited) && $dt[strtolower($type)]["enable"] != "ALL" ) {
+  $dom->unlock();
   $msg->raise("ERROR", "dom", _("This page is restricted to authorized staff"));
   include("dom_edit.php");
   exit();

--- a/bureau/class/m_dom.php
+++ b/bureau/class/m_dom.php
@@ -459,6 +459,7 @@ class m_dom {
 
         // function add_domain($domain,$dns,$noerase=0,$force=0,$isslave=0,$slavedom="") 
         if (!$this->add_domain($domain, true, false, true)) {
+            $this->unlock();
             $msg->raise("ERROR", 'dom', "Error adding domain");
             return false;
         }
@@ -642,6 +643,7 @@ class m_dom {
 
         $this->lock();
         if (!$r = $this->get_domain_all($domain)) {
+            $this->unlock();
             return false;
         }
         $this->unlock();


### PR DESCRIPTION
If we don't do this, we'll end up trying to lock a domain again
somewhere else and hitting the condition labeled with:

    Program error --- Lock already obtained!