### PR TITLE
proftpd.conf: Default to modern TLS protocols

### DIFF
--- a/etc/alternc/templates/proftpd/proftpd.conf
+++ b/etc/alternc/templates/proftpd/proftpd.conf
@@ -124,7 +124,11 @@ RLimitChroot off
 <IfModule mod_tls.c>
        TLSEngine on
        TLSLog /var/log/proftpd/tls.log
-       TLSProtocol TLSv1
+       # TLSv1.3 has bugs before ProFTPd 1.3.6d and 1.3.7
+       #TLSProtocol TLSv1.2 TLSv1.3
+       TLSProtocol TLSv1.2
+       # For old clients
+       #TLSProtocol TLSv1 TLSv1.1 TLSv1.2
 
        # Are clients required to use FTP over TLS when talking to this server?
        TLSRequired off


### PR DESCRIPTION
# Rationale

TLSv1.2 has been out for more than 10 years, and is now widely available. TLSv1.0 and TLSv1.1 are known to be unsufficient for a few years and have been officially deprecated by the IETF recently.

TLSv1.3 is starting to be widely available, however it had implementation bugs, such as https://github.com/proftpd/proftpd/issues/959. This is fixed upstream, but fixed versions are not available in Debian 10 yet.

# Changes

* ProFTPd now defaults to TLSv1.2
* Add a comment for suggesting other values like TLSv1.3, but with a comment about buggy versions
* Add a comment for downgrading to deprecated TLSv1 TLSv1.1