### PR TITLE
alternc.install: PHP version comparison is broken for buster

### DIFF
--- a/install/alternc.install
+++ b/install/alternc.install
@@ -338,7 +338,7 @@ rm -f $SED_SCRIPT
 
 # add php.ini directives for AlternC in any installed php version:
 php="`ls /usr/lib/apache*/*/*php*.so | sed -e 's/^.*libphp\(.*\)\.so$/\1/' | tail -1`"
-if [ "$php" = "7.0" ]
+if ! [[ "$php" < "7" ]]
 then
     ln -fs /etc/alternc/alternc.ini /etc/php/$php/apache2/conf.d/alternc.ini || true
     ln -fs /etc/alternc/alternc.ini /etc/php/$php/cli/conf.d/alternc.ini || true


### PR DESCRIPTION
The current comparison can only work on debian stretch, that ships php
7.0, but debian buster has a more recent version and bullseye will have
an even more recent version.

This change was suggested by @ulvida (Daniel Viñar Ulriksen) on Github.
Thanks!

Closes: #459