### PR TITLE
Closes #404, Configures opendkim in buster and upper

### DIFF
--- a/install/alternc.install
+++ b/install/alternc.install
@@ -667,7 +667,7 @@ grep -q "^127.0.0.1\$" /etc/opendkim/TrustedHosts || echo "127.0.0.1" >>/etc/ope
 grep -q "^localhost\$" /etc/opendkim/TrustedHosts || echo "localhost" >>/etc/opendkim/TrustedHosts
 grep -q "^$PUBLIC_IP\$" /etc/opendkim/TrustedHosts || echo "$PUBLIC_IP" >>/etc/opendkim/TrustedHosts
 
-if [ "$SYSTEMD" = "1" -a "$(lsb_release -s -c)" = "stretch" ] ; then
+if [[ "$SYSTEMD" = "1" && ! "$(lsb_release -s -c)" =~ ^(jessie|wheezy)$ ]] ; then
     /lib/opendkim/opendkim.service.generate
     # Without adding '-u opendkim' after the service file is generated, opendkim
     # will run as root, which we do not want.


### PR DESCRIPTION
In `buster`, and better also in future debian releases, `alternc.install` should configure opendkim as it does for `stretch`.  See #404 and #472. 

Close #404 #472