### PR TITLE
Fixes #482: Improve feedback to users when protecting folder with htaccess

### DIFF
--- a/bureau/admin/hta_doadd.php
+++ b/bureau/admin/hta_doadd.php
@@ -37,7 +37,6 @@ if(empty($dir)) {
 	$is_include=true;
 	include("hta_add.php");
 } else {
-	$msg->raise("INFO", "hta", _("Folder %s is protected"), $dir);
 	include("hta_list.php");
 }
 ?>

--- a/bureau/class/m_hta.php
+++ b/bureau/class/m_hta.php
@@ -71,6 +71,7 @@ class m_hta {
             $msg->raise("ERROR", "hta", _("The folder '%s' does not exist"), $dir);
             return false;
         }
+        $param = "AuthUserFile \"$absolute/.htpasswd\"\nAuthName \"" . _("Restricted area") . "\"\nAuthType Basic\nrequire valid-user\n";
         if (!file_exists("$absolute/.htaccess")) {
             $file = @fopen("$absolute/.htaccess", "w+");
             if (!$file) {
@@ -78,15 +79,23 @@ class m_hta {
                 return false;
             }
             fseek($file, 0);
-            $param = "AuthUserFile \"$absolute/.htpasswd\"\nAuthName \"" . _("Restricted area") . "\"\nAuthType Basic\nrequire valid-user\n";
             fwrite($file, $param);
             fclose($file);
+            $msg->raise("INFO", "hta", _("Added .htaccess file to restrict '%s' to valid users"), array($dir));
+        }
+        else {
+            # The .htaccess file already exists, and we don't try to overwrite the existing
+            # contents, therefore we inform that they need to make the modifications to
+            # the htaccess file manually.
+            $msg->raise("ALERT", "hta", _("The .htaccess file already existed in '%s', you must add the following lines manually to '%s'\n"), array($dir, $dir . "/.htaccess"));
+            $msg->raise("ALERT", "hta", $param);
         }
         if (!file_exists("$absolute/.htpasswd")) {
             if (!@touch("$absolute/.htpasswd")) {
                 $msg->raise("ERROR", "hta", _("Error creating .htpasswd file: ") . error_get_last()['message']);
                 return false;
             }
+            $msg->raise("INFO", "hta", _("Added .htpasswd to Folder '%s', you may now add users who will be able to access it."), $dir);
             return true;
         }
         return true;


### PR DESCRIPTION
The current behaviour of protecting a folder only modifies adds the
relevant .htaccess configuration lines if the file doesn't already
exist. In the case that it exists, no change is made and it appears to
"not work" for users.

This commit improves the feedbackup to users about what is happening,
and gives them the necessary information to modify their custom
.htaccess file with the appropriate configuration lines.