### PR TITLE
user piwik account quota instead of hardcoded value

### DIFF
--- a/bureau/admin/piwik_addaccount.php
+++ b/bureau/admin/piwik_addaccount.php
@@ -28,18 +28,20 @@ require_once("../class/config.php");
 $userslist = $piwik->users_list();
 $quotapiwik = $quota->getquota('piwik');
 
-if (!($quotapiwik['t'] > 0 && count($userslist) < 3)) {
-	$msg->raise("ERROR", "piwik", _("You cannot add any new Piwik account, your quota is over.")." ("._("Max. 3 accounts").")");
+if (!($quotapiwik['t'] > 0 && count($userslist) < $quotapiwik['t'])) {
+  $msg->raise("ERROR", "piwik", _("You cannot add any new Piwik account, your quota is over.")." (".sprintf(_("Max. %d accounts"), $quotapiwik['t']).")");
+}
+else {
+  $fields = array (
+      "account_name" => array ("post", "string", ""),
+      "account_mail" => array ("post", "string", ""),
+  );
+  getFields($fields);
+
+  if ($piwik->user_add($account_name, $account_mail) ) {
+    $msg->raise("INFO", "piwik", _('Successfully added piwik account'));
+  }
 }
 
-$fields = array (
-	"account_name" 		=> array ("post", "string", ""),
-	"account_mail" 		=> array ("post", "string", ""),
-);
-getFields($fields);
-
-if ($piwik->user_add($account_name, $account_mail) ) {
-  $msg->raise("INFO", "piwik", _('Successfully added piwik account'));
-}
 include_once("piwik_userlist.php");
 ?>

--- a/bureau/admin/piwik_userlist.php
+++ b/bureau/admin/piwik_userlist.php
@@ -29,8 +29,7 @@ include_once("head.php");
 $userslist = $piwik->users_list();
 $quotapiwik = $quota->getquota('piwik');
 
-// TODO - Put the limit of piwik users (here at 3) as a variable in alternC
-if ($quotapiwik['t'] > 0 && count($userslist) < 3) {
+if ($quotapiwik['t'] > 0 && count($userslist) < $quotapiwik['t']) {
 ?>
 <h3><?php __("Create a new piwik account");?></h3>
 <?php
@@ -51,7 +50,7 @@ echo $msg->msg_html_all(true, true);
 	<input type="submit" name="submit" class="inb" value="<?php __("Create"); ?>" />
 	</tr>
 	</table>
-	<i>(<?php ehe("Max. 3 accounts"); ?>)</i>
+	<i>(<?php ehe(sprintf(_("Max. %d accounts"), $quotapiwik['t'])); ?>)</i>
 </form>
 <script type="text/javascript">
     document.forms['main'].account_name.focus();


### PR DESCRIPTION
The code is already getting the value of the piwik quota ... so why is
it not using said quota?

There was also another bug in the code: if a quota issue was detected,
the piwik account creation was still proceeding nonetheless. This change
makes it so that an account is not created if a quota issue is detected.