### PR TITLE
[fix] subdomains leak

### DIFF
--- a/bureau/class/m_bind.php
+++ b/bureau/class/m_bind.php
@@ -226,7 +226,8 @@ class m_bind {
           sd.type=dt.name
           AND sd.enable IN ('ENABLE', 'ENABLED')
           AND sd.web_action NOT IN ('DELETE')
-        ORDER BY ENTRY ;");
+          AND sd.domaine = ?
+        ORDER BY ENTRY ;",array($domain));
         $t="";
         while ($db->next_record()) {
             $t.= $db->f('ENTRY')."\n";


### PR DESCRIPTION
When updating a DNS zone, AlternC writes out all subdomains, not only
the subdomains of the current domain.

This commit adds the missing filter.