### PR TITLE
Allow dnssec feature

### DIFF
--- a/bureau/class/m_bind.php
+++ b/bureau/class/m_bind.php
@@ -41,8 +41,27 @@ class m_bind {
      * @NOTE launched as ROOT 
      */
     function hook_updatedomains_dns_pre() {
+        global $msg;
+
         $this->shouldreload=false;
         $this->shouldreconfig=false;
+
+        //Prevent some race condition with dynamic zone (as dns-sec behavior)
+        $ret=0;
+        exec($this->RNDC." sync -clean 2>&1",$out,$ret);
+        if ($ret!=0) {
+            $msg->raise("ERROR","bind","Error while sync bind, error code is $ret\n".implode("\n",$out));
+        } else {
+            $msg->raise("INFO","bind","Bind sync done");
+        }
+
+        $ret=0;
+        exec($this->RNDC." freeze 2>&1",$out,$ret);
+        if ($ret!=0) {
+            $msg->raise("ERROR","bind","Error while freeze bind, error code is $ret\n".implode("\n",$out));
+        } else {
+            $msg->raise("INFO","bind","Bind freeze done");
+        }
     }
 
 
@@ -158,6 +177,15 @@ class m_bind {
      */ 
     function hook_updatedomains_dns_post() {
         global $msg;
+
+        $ret=0;
+        exec($this->RNDC." thaw 2>&1",$out,$ret);
+        if ($ret!=0) {
+            $msg->raise("ERROR","bind","Error while thawing bind, error code is $ret\n".implode("\n",$out));
+        } else {
+            $msg->raise("INFO","bind","Bind thaw done");
+        }
+
         if ($this->shouldreload) {
             $ret=0;
             exec($this->RNDC." reload 2>&1",$out,$ret);

--- a/debian/alternc.postinst
+++ b/debian/alternc.postinst
@@ -252,6 +252,8 @@ NFS_QUOTA=no" >> $CONFIGFILE
     touch           /var/lib/alternc/bind/automatic.conf /var/lib/alternc/bind/slaveip.conf
     chown root:bind /var/lib/alternc/bind/automatic.conf /var/lib/alternc/bind/slaveip.conf
     chmod 640       /var/lib/alternc/bind/automatic.conf /var/lib/alternc/bind/slaveip.conf
+    chown root:bind /var/lib/alternc/bind/zones/
+    chmod 775       /var/lib/alternc/bind/zones/
     mkdir -p /run/alternc && chown alterncpanel:alterncpanel /run/alternc
     touch /run/alternc/refresh_slave
     /usr/lib/alternc/slave_dns


### PR DESCRIPTION
Should solve #523 issue

* AlternC can accept dnssec feature without break anything
* Admin sys must enable feature on its templates */etc/alternc/templates/bind/templates/*  and add **dnssec-policy default;**  option himself
