### PR TITLE
[scripts] LOGS_COMPRESS_DAYS and LOGS_DELETE_DAYS

### DIFF
--- a/debian/alternc.postinst
+++ b/debian/alternc.postinst
@@ -134,6 +134,14 @@ ALTERNC_LOGS=""
 # called from the panel. To enable quota-over-NFS, put yes here
 NFS_QUOTA=no
 
+# How long do we wait before compressing the log
+# default is 2
+LOGS_COMPRESS_DAYS=2
+
+# How many day do we keep the logs?
+# defautl is 366 day
+LOGS_DELETE_DAYS=366
+
 EOF
 
         chown root:alterncpanel $CONFIGFILE
@@ -173,6 +181,18 @@ EOF
 # the default is NO, since this dramatically block /usr/lib/alternc/quota* functions
 # called from the panel. To enable quota-over-NFS, put yes here
 NFS_QUOTA=no" >> $CONFIGFILE
+
+    # Add LOGS_COMPRESS_DAYS
+    grep -Eq "^ *LOGS_COMPRESS_DAYS=" $CONFIGFILE || echo "
+# How long do we wait before compressing the log
+# default is 2
+LOGS_COMPRESS_DAYS=2" >> $CONFIGFILE
+
+    # Add LOGS_DELETE_DAYS
+    grep -Eq "^ *LOGS_DELETE_DAYS=" $CONFIGFILE || echo "
+# How many day do we keep the logs?
+# defautl is 366 day
+LOGS_DELETE_DAYS=366" >> $CONFIGFILE
 
     # Erase all apacheconf file
     # They will be regenerated without the bug by upgrade_check.sh below.

--- a/src/compress_logs.sh
+++ b/src/compress_logs.sh
@@ -1,8 +1,5 @@
 #! /bin/bash
 
-# How long do we wait before compressing the log? Default: 2
-LOGS_COMPRESS_DAYS=2
-
 for CONFIG_FILE in \
       /etc/alternc/local.sh \
       /usr/lib/alternc/functions.sh
@@ -13,6 +10,9 @@ for CONFIG_FILE in \
     fi
     . "$CONFIG_FILE"
 done
+
+# How long do we wait before compressing the log? Default: 2
+LOGS_COMPRESS_DAYS="${LOGS_COMPRESS_DAYS:-2}"
 
 stop_if_jobs_locked
 

--- a/src/compress_logs.sh
+++ b/src/compress_logs.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
-# How long do we wait before compressing the log ? Default: 2
-DAYS=2
+# How long do we wait before compressing the log? Default: 2
+LOGS_COMPRESS_DAYS=2
 
 for CONFIG_FILE in \
       /etc/alternc/local.sh \
@@ -19,5 +19,4 @@ stop_if_jobs_locked
 # ALTERNC_LOGS is from local.sh
 
 #Compress logs older than XX days
-nice -n 10 find "$ALTERNC_LOGS" -type f -name '*.log' -mtime +$DAYS -exec gzip '{}' \;
-
+nice -n 10 find "$ALTERNC_LOGS" -type f -name '*.log' -mtime +$LOGS_COMPRESS_DAYS -exec gzip '{}' \;

--- a/src/delete_logs.sh
+++ b/src/delete_logs.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# How many day do we keep the logs?
-LOGS_DELETE_DAYS=366
-
 for CONFIG_FILE in \
       /etc/alternc/local.sh \
       /usr/lib/alternc/functions.sh
@@ -13,6 +10,9 @@ for CONFIG_FILE in \
     fi
     . "$CONFIG_FILE"
 done
+
+# How many day do we keep the logs?
+LOGS_DELETE_DAYS="${LOGS_DELETE_DAYS:-366}"
 
 stop_if_jobs_locked
 

--- a/src/delete_logs.sh
+++ b/src/delete_logs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# How many day do we keep the logs ?
-DAYS=366
+# How many day do we keep the logs?
+LOGS_DELETE_DAYS=366
 
 for CONFIG_FILE in \
       /etc/alternc/local.sh \
@@ -17,4 +17,4 @@ done
 stop_if_jobs_locked
 
 # ALTERNC_LOGS is from local.sh
-find "$ALTERNC_LOGS" -type f -mtime +$DAYS -delete
+find "$ALTERNC_LOGS" -type f -mtime +$LOGS_DELETE_DAYS -delete


### PR DESCRIPTION
Fixes #536

compress_logs.sh and delete_logs.sh use the same DAYS variable, which forbid customization in local.sh without affecting both housekeeping scripts at the same time.

This commit rename both variable to distinct and more explicit names.