### PR TITLE
[fix] import of CNAME in DNS zone

### DIFF
--- a/bureau/class/m_dom.php
+++ b/bureau/class/m_dom.php
@@ -346,7 +346,8 @@ class m_dom {
                             // Examples:
                             // agenda IN CNAME ghs.google.com.
                             // www 3600 IN CNAME @
-                            if (preg_match('/^(?P<sub>[\-\w\.@]*)\h*(?P<ttl>\d*)\h*IN\h+CNAME\h+(?P<target>[@\w+\.\-]+)/i', $zone, $ret)) {
+                            // foo CNAME bar.example.com.
+                            if (preg_match('/^(?P<sub>[\-\w\.@]*)\h*(?P<ttl>\d*)\h*(IN)?\h+CNAME\h+(?P<target>[@\w+\.\-]+)/i', $zone, $ret)) {
                                 if (substr($ret['sub'], -1) == '.') { // if ending by a "." it is allready a FQDN
                                     $url = "http://" . $ret['sub'];
                                 } else {


### PR DESCRIPTION
By default, AlternC writes out CNAMEs as "foo CNAME bar" instead of "foo IN CNAME bar" in the generated DNS zones. This patch allows importing CNAMEs from another AlternC.

backport from #531 as master branch was deleted