### PR TITLE
Issue 605 - Reduce csrf colission risk

### DIFF
--- a/bureau/class/config.php
+++ b/bureau/class/config.php
@@ -61,10 +61,6 @@ if (!empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
     $_REQUEST["password"] = $_SERVER['PHP_AUTH_PW'];
 }
 
-// proper srand (not using time(), which is what PHP does!)
-list($usec, $sec) = explode(" ", microtime());
-mt_srand($usec * 1000000);
-
 /* Server Domain Name */
 $host = getenv("HTTP_HOST");
 


### PR DESCRIPTION
As explained in #605 , Mersenne Twister can generate token collision quickly.
We try to reduce this risk with :
* increase random seed using default behavior
* try at least 5 times before to break page home loading

close #605 