### PR TITLE
Allow 127.0.0.1 as valid MYSQL_HOST

### DIFF
--- a/install/alternc.install
+++ b/install/alternc.install
@@ -663,7 +663,7 @@ if [ "$HAS_ROOT" != "1" ]; then
     fi
 else
     ##UPDATE default db_server following /etc/alternc/my.cnf values
-    if [ "$MYSQL_HOST" == "localhost" ]; then
+    if [ "$MYSQL_HOST" == "localhost" ] || [ "$MYSQL_HOST" == "127.0.0.1" ]; then
         MYSQL_HOST_CLIENT="localhost"
     else
         MYSQL_HOST_CLIENT="%"


### PR DESCRIPTION
On some older setup of AlternC, the file `/etc/alternc/my.cnf` can have `127.0.0.1` instead of `localhost`, the condition will not be the same as it does and the bug https://github.com/AlternC/AlternC/issues/554 appears.